### PR TITLE
Add markdown rendering to chat UI

### DIFF
--- a/checklist.md
+++ b/checklist.md
@@ -10,7 +10,7 @@
 ### Phase 2: Core Features (Weeks 5-8)
 
 - [x] Model download manager
-- [ ] Enhanced chat UI with markdown
+- [x] Enhanced chat UI with markdown
 - [ ] Settings and preferences
 - [ ] Export functionality
 

--- a/docs/chat/overview.md
+++ b/docs/chat/overview.md
@@ -2,14 +2,14 @@
 
 ## Feature Purpose and Scope
 
-Provide a simple interface for conversational interaction with a selected model using Ollama's streaming chat API. Messages are exchanged with a minimal UI suitable for early testing.
+Provide a simple interface for conversational interaction with a selected model using Ollama's streaming chat API. Messages are exchanged with a minimal UI suitable for early testing. The UI renders assistant responses using Markdown with syntax highlighting and safe sanitization.
 
 ## Core Flows and UI Touchpoints
 
 - Users type messages in the `ChatInput` component.
 - The `sendMessage` action in `chat-store` forwards the conversation to `OllamaClient.chat()`.
 - Streaming responses are appended to the message list in real time.
-- Messages are displayed with the `ChatMessage` component inside `ChatInterface`.
+- Messages are displayed with the `ChatMessage` component inside `ChatInterface`, which parses assistant responses as Markdown.
 
 ## Primary Types
 
@@ -23,6 +23,7 @@ Types are defined in [`/types/ollama`](../../types/ollama).
 - `OllamaClient` from `src/lib/ollama/client.ts`
 - Zustand store in `stores/chat-store.ts`
 - React components under `components/chat`
+- `react-markdown` with `remark-gfm`, `rehype-highlight`, and `rehype-sanitize` for secure Markdown rendering
 
 ## Architecture Diagram
 

--- a/ollama-ui/components/chat/ChatMessage.tsx
+++ b/ollama-ui/components/chat/ChatMessage.tsx
@@ -1,6 +1,10 @@
 "use client";
 import type { ChatMessage as Message } from "@/types";
 import { cn } from "@/lib/utils";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeHighlight from "rehype-highlight";
+import rehypeSanitize from "rehype-sanitize";
 
 interface ChatMessageProps {
   message: Message;
@@ -12,8 +16,38 @@ export const ChatMessage = ({ message }: ChatMessageProps) => {
   const align = isUser ? "self-end" : "self-start";
 
   return (
-    <div className={cn("max-w-sm p-3 rounded-md", bubble, align)}>
-      {message.content}
+    <div className={cn("prose max-w-sm p-3 rounded-md", bubble, align)}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        rehypePlugins={[rehypeHighlight, rehypeSanitize]}
+        components={{
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          code({ inline, className, children, ...props }: any) {
+            const content = String(children).replace(/\n$/, "");
+            if (inline) {
+              return (
+                <code className={className} {...props}>
+                  {children}
+                </code>
+              );
+            }
+            return (
+              <pre className="relative">
+                <button
+                  type="button"
+                  className="absolute top-2 right-2 text-xs text-gray-500"
+                  onClick={() => navigator.clipboard.writeText(content)}
+                >
+                  Copy
+                </button>
+                <code className={className} {...props}>{children}</code>
+              </pre>
+            );
+          },
+        }}
+      >
+        {message.content}
+      </ReactMarkdown>
     </div>
   );
 };

--- a/ollama-ui/package.json
+++ b/ollama-ui/package.json
@@ -26,6 +26,7 @@
     "react-hook-form": "^7.57.0",
     "react-markdown": "^10.1.0",
     "rehype-highlight": "^7.0.2",
+    "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "tiktoken": "^1.0.21",
     "zod": "^3.25.64",


### PR DESCRIPTION
## Summary
- support Markdown in ChatMessage with syntax highlighting
- secure markdown rendering via rehype-sanitize
- add code block copy button
- document enhanced markdown chat UI
- mark checklist item complete

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_684c4101beac83239e513acab0f190b3