### PR TITLE
Add runnable and editable code blocks

### DIFF
--- a/docs/markdown/overview.md
+++ b/docs/markdown/overview.md
@@ -10,6 +10,8 @@ Provide rich rendering of assistant responses including multi-file code blocks, 
 - Code snippets displayed via `CodeBlock` or `MultiTabCodeBlock`
 - Theme toggle available from `ThemeProvider`
 - Code highlighting theme controlled via `CodeThemeProvider`
+- Code blocks can be run inline for JavaScript and Python
+- Snippets are editable via a Monaco editor with auto-save
 
 -## Primary Types
 

--- a/md-viewer-adv-docs/markdown-chat-component.tsx
+++ b/md-viewer-adv-docs/markdown-chat-component.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useMemo } from 'react';
-import { Check, Copy, Code2, FileText, Maximize2, Download, Search, Sparkles, ChevronRight, ChevronDown, Terminal, Braces, Hash, FileCode, Database, Layers, Palette } from 'lucide-react';
+import { Check, Copy, Code2, FileText, Maximize2, Download, Search, Sparkles, ChevronRight, ChevronDown, Terminal, Braces, Hash, FileCode, Database, Layers, Palette, Play, Pencil } from 'lucide-react';
 
 // Simulated syntax highlighting (in production, use Prism.js)
 const highlightCode = (code, language) => {
@@ -51,6 +51,9 @@ const getLanguageIcon = (lang) => {
 const CodeBlock = ({ code, language, filename, isActive, onCopy }) => {
   const [copied, setCopied] = useState(false);
   const [showLineNumbers, setShowLineNumbers] = useState(true);
+  const [editing, setEditing] = useState(false);
+  const [codeText, setCodeText] = useState(code);
+  const [output, setOutput] = useState('');
   
   const handleCopy = () => {
     navigator.clipboard.writeText(code);
@@ -59,9 +62,23 @@ const CodeBlock = ({ code, language, filename, isActive, onCopy }) => {
     setTimeout(() => setCopied(false), 2000);
   };
   
-  const lines = code.trim().split('\n');
-  const highlightedCode = useMemo(() => highlightCode(code, language), [code, language]);
+  const lines = codeText.trim().split('\n');
+  const highlightedCode = useMemo(() => highlightCode(codeText, language), [codeText, language]);
   const highlightedLines = highlightedCode.split('\n');
+
+  const handleRun = () => {
+    try {
+      if (language === 'javascript') {
+        // eslint-disable-next-line no-eval
+        const result = eval(codeText);
+        setOutput(String(result));
+      } else {
+        setOutput('python execution not implemented');
+      }
+    } catch (e) {
+      setOutput('Error: ' + e.message);
+    }
+  };
   
   return (
     <div className={`code-block ${isActive ? 'active' : 'hidden'}`}>
@@ -71,14 +88,14 @@ const CodeBlock = ({ code, language, filename, isActive, onCopy }) => {
           <span>{language}</span>
         </div>
         <div className="code-actions">
-          <button 
+          <button
             className="action-btn"
             onClick={() => setShowLineNumbers(!showLineNumbers)}
             title="Toggle line numbers"
           >
             <Hash className="w-4 h-4" />
           </button>
-          <button 
+          <button
             className="action-btn"
             onClick={handleCopy}
             title="Copy code"
@@ -89,27 +106,42 @@ const CodeBlock = ({ code, language, filename, isActive, onCopy }) => {
               <Copy className="w-4 h-4" />
             )}
           </button>
+          <button className="action-btn" onClick={handleRun} title="Run code">
+            <Play className="w-4 h-4" />
+          </button>
+          <button className="action-btn" onClick={() => setEditing(!editing)} title="Edit code">
+            <Pencil className="w-4 h-4" />
+          </button>
           <button className="action-btn" title="Fullscreen">
             <Maximize2 className="w-4 h-4" />
           </button>
         </div>
       </div>
       <div className="code-content">
-        <pre>
-          <code>
-            {highlightedLines.map((line, i) => (
-              <div key={i} className="code-line">
-                {showLineNumbers && (
-                  <span className="line-number">{i + 1}</span>
-                )}
-                <span 
-                  className="line-content" 
-                  dangerouslySetInnerHTML={{ __html: line || '&nbsp;' }}
-                />
-              </div>
-            ))}
-          </code>
-        </pre>
+        {editing ? (
+          <textarea
+            value={codeText}
+            onChange={(e) => setCodeText(e.target.value)}
+            className="w-full h-40 bg-gray-800 text-white p-2 font-mono"
+          />
+        ) : (
+          <pre>
+            <code>
+              {highlightedLines.map((line, i) => (
+                <div key={i} className="code-line">
+                  {showLineNumbers && (
+                    <span className="line-number">{i + 1}</span>
+                  )}
+                  <span
+                    className="line-content"
+                    dangerouslySetInnerHTML={{ __html: line || '&nbsp;' }}
+                  />
+                </div>
+              ))}
+            </code>
+          </pre>
+        )}
+        {output && <pre className="mt-2 text-sm">{output}</pre>}
       </div>
     </div>
   );

--- a/ollama-ui/components/markdown/CodeBlock.tsx
+++ b/ollama-ui/components/markdown/CodeBlock.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState, useEffect, useId } from "react";
+import { useState, useEffect, useId, useMemo } from "react";
 import Prism from "prismjs";
 
 const loadLanguage = async (lang: string) => {
@@ -10,34 +10,110 @@ const loadLanguage = async (lang: string) => {
     // ignore missing language
   }
 };
-import { Copy, Check, Download, Maximize2, X, Hash, Search } from "lucide-react";
+import {
+  Copy,
+  Check,
+  Download,
+  Maximize2,
+  X,
+  Hash,
+  Search,
+  Play,
+  Pencil,
+} from "lucide-react";
+import dynamic from "next/dynamic";
 import { createPortal } from "react-dom";
 import type { CodeBlock as Block, ExportFormat } from "@/types";
+
+const MonacoEditor = dynamic(() => import("@monaco-editor/react"), { ssr: false });
+
+const execute = (src: string, lang: string): Promise<string> => {
+  return new Promise((resolve) => {
+    const iframe = document.createElement("iframe");
+    iframe.sandbox.add("allow-scripts");
+    iframe.style.display = "none";
+    const handler = (e: MessageEvent) => {
+      if (e.source === iframe.contentWindow) {
+        resolve(typeof e.data === "string" ? e.data : JSON.stringify(e.data));
+        window.removeEventListener("message", handler);
+        iframe.remove();
+      }
+    };
+    window.addEventListener("message", handler);
+    if (lang === "javascript") {
+      iframe.srcdoc = `<script>window.parent.postMessage((()=>{try{return eval(${JSON.stringify(
+        src
+      )});}catch(e){return 'Error: '+e.message}})(),'*');<\/script>`;
+    } else {
+      iframe.srcdoc = `<!doctype html><script src="https://cdn.jsdelivr.net/pyodide/v0.25.1/full/pyodide.js"></script><script>async function r(){const p=await loadPyodide();try{const res=await p.runPythonAsync(${JSON.stringify(
+        src
+      )});parent.postMessage(res,'*');}catch(e){parent.postMessage('Error: '+e.message,'*')}}r();<\/script>`;
+    }
+    document.body.appendChild(iframe);
+  });
+};
 
 interface CodeBlockProps extends Block {
   search?: string;
   onSearchChange?: (value: string) => void;
+  /** show run button and execute code */
+  runnable?: boolean;
+  /** enable editing via Monaco */
+  editable?: boolean;
+  /** callback when code is run */
+  onRunResult?: (output: string) => void;
+  /** callback when edited code is saved */
+  onCodeChange?: (code: string) => void;
 }
 
-export const CodeBlock = ({ code, language, filename, highlight = [], search: externalSearch = "", onSearchChange }: CodeBlockProps) => {
+export const CodeBlock = ({
+  code,
+  language,
+  filename,
+  highlight = [],
+  search: externalSearch = "",
+  onSearchChange,
+  runnable = language === "javascript" || language === "python",
+  editable = false,
+  onRunResult,
+  onCodeChange,
+}: CodeBlockProps) => {
   const [copied, setCopied] = useState(false);
   const [showNumbers, setShowNumbers] = useState(true);
   const [fullscreen, setFullscreen] = useState(false);
   const [search, setSearch] = useState(externalSearch);
   const [highlighted, setHighlighted] = useState<string[]>([]);
   const [filtered, setFiltered] = useState<string[]>([]);
+  const [editing, setEditing] = useState(false);
+  const [codeText, setCodeText] = useState(code);
+  const [runOutput, setRunOutput] = useState<string>("");
   const id = useId();
+  const storageKey = useMemo(() => `cb-${id}`, [id]);
 
   useEffect(() => {
     setSearch(externalSearch);
   }, [externalSearch]);
 
   useEffect(() => {
+    const stored = localStorage.getItem(storageKey);
+    if (stored) {
+      setCodeText(stored);
+    }
+  }, [storageKey]);
+
+  useEffect(() => {
+    if (editing) {
+      localStorage.setItem(storageKey, codeText);
+      onCodeChange?.(codeText);
+    }
+  }, [codeText, editing, storageKey, onCodeChange]);
+
+  useEffect(() => {
     let cancelled = false;
     (async () => {
       await loadLanguage(language);
       const html = Prism.highlight(
-        code,
+        codeText,
         Prism.languages[language] || Prism.languages.plain,
         language
       );
@@ -48,7 +124,7 @@ export const CodeBlock = ({ code, language, filename, highlight = [], search: ex
     return () => {
       cancelled = true;
     };
-  }, [code, language]);
+  }, [codeText, language]);
 
   useEffect(() => {
     if (!search) {
@@ -67,7 +143,7 @@ export const CodeBlock = ({ code, language, filename, highlight = [], search: ex
 
   const handleCopy = async () => {
     try {
-      await navigator.clipboard.writeText(code);
+      await navigator.clipboard.writeText(codeText);
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
     } catch {
@@ -76,16 +152,16 @@ export const CodeBlock = ({ code, language, filename, highlight = [], search: ex
   };
 
   const handleDownload = (format: ExportFormat) => {
-    let data = code;
+    let data = codeText;
     let mime = "text/plain";
     if (format === "html") {
-      data = `<pre>${code}</pre>`;
+      data = `<pre>${codeText}</pre>`;
       mime = "text/html";
     }
     if (format === "pdf") {
       const win = window.open("", "_blank");
       if (win) {
-        win.document.write(`<pre>${code}</pre>`);
+        win.document.write(`<pre>${codeText}</pre>`);
         win.print();
         win.close();
       }
@@ -148,6 +224,30 @@ export const CodeBlock = ({ code, language, filename, highlight = [], search: ex
           >
             <Download className="w-4 h-4" />
           </button>
+          {runnable && (
+            <button
+              type="button"
+              aria-label="Run code"
+              onClick={async () => {
+                const out = await execute(codeText, language);
+                setRunOutput(out);
+                onRunResult?.(out);
+              }}
+              className="text-gray-400 hover:text-white"
+            >
+              <Play className="w-4 h-4" />
+            </button>
+          )}
+          {editable && (
+            <button
+              type="button"
+              aria-label="Edit code"
+              onClick={() => setEditing((e) => !e)}
+              className="text-gray-400 hover:text-white"
+            >
+              <Pencil className="w-4 h-4" />
+            </button>
+          )}
           <button
             type="button"
             aria-label="Fullscreen"
@@ -170,21 +270,38 @@ export const CodeBlock = ({ code, language, filename, highlight = [], search: ex
           className="mb-2 w-full rounded bg-gray-800 px-2 py-1 text-xs outline-none"
           placeholder="Search..."
         />
-        <pre className="relative overflow-x-auto">
-          <code className={`language-${language} block`}>
-            {lines.map((line, i) => (
-              <div
-                key={i}
-                className={`whitespace-pre ${highlight.includes(i + 1) ? "bg-yellow-900/40" : ""}`}
-              >
-                {showNumbers && (
-                  <span className="select-none text-gray-500 mr-3">{i + 1}</span>
-                )}
-                <span dangerouslySetInnerHTML={{ __html: line }} />
-              </div>
-            ))}
-          </code>
-        </pre>
+        {editing ? (
+          <div className="h-72">
+            <MonacoEditor
+              language={language}
+              value={codeText}
+              onChange={(val) => setCodeText(val || "")}
+              theme="vs-dark"
+              height="100%"
+            />
+          </div>
+        ) : (
+          <pre className="relative overflow-x-auto">
+            <code className={`language-${language} block`}>
+              {lines.map((line, i) => (
+                <div
+                  key={i}
+                  className={`whitespace-pre ${highlight.includes(i + 1) ? "bg-yellow-900/40" : ""}`}
+                >
+                  {showNumbers && (
+                    <span className="select-none text-gray-500 mr-3">{i + 1}</span>
+                  )}
+                  <span dangerouslySetInnerHTML={{ __html: line }} />
+                </div>
+              ))}
+            </code>
+          </pre>
+        )}
+        {runOutput && (
+          <pre className="mt-2 p-2 bg-gray-800 rounded text-xs overflow-auto">
+            {runOutput}
+          </pre>
+        )}
       </div>
     </div>
   );

--- a/ollama-ui/package.json
+++ b/ollama-ui/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@hookform/resolvers": "^5.1.1",
     "@lancedb/lancedb": "^0.20.0",
+    "@monaco-editor/react": "^4.7.0",
     "@tanstack/react-query": "^5.80.7",
     "@types/prismjs": "^1.26.5",
     "@uiw/react-md-editor": "^4.0.7",
@@ -22,6 +23,7 @@
     "framer-motion": "^12.18.1",
     "katex": "^0.16.22",
     "lucide-react": "^0.515.0",
+    "monaco-editor": "^0.52.2",
     "next": "15.3.3",
     "openai": "^5.3.0",
     "prismjs": "^1.30.0",


### PR DESCRIPTION
## Summary
- make `CodeBlock` runnable and editable
- reference new controls in the markdown chat component example
- document runnable and editable code blocks in markdown docs
- include monaco editor dependency

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_684c7a06cf9c83238d0ed13d5a145301