### PR TITLE
Implement export feature

### DIFF
--- a/checklist.md
+++ b/checklist.md
@@ -15,7 +15,7 @@ For recommended system prompts that produce advanced markdown features, see [doc
 - [x] Enhanced chat UI with markdown
 - [x] Advanced Markdown integration
 - [x] Settings and preferences
-- [ ] Export functionality
+- [x] Export functionality
 
 ### Phase 3: Advanced Features (Weeks 9-12)
 

--- a/docs/export/overview.md
+++ b/docs/export/overview.md
@@ -1,0 +1,35 @@
+# Export Functionality
+
+## Feature Purpose and Scope
+
+Allow users to save chat conversations from the application. Conversations can be
+exported in Markdown, PDF or JSON formats for sharing or archival.
+
+## Core Flows and UI Touchpoints
+
+- Export buttons available in the chat header via `ExportMenu`.
+- Selected format triggers `exportConversation` which converts the message list.
+- Downloaded file uses the chosen `ExportFormat`.
+
+## Primary Types
+
+- `ChatMessage` – conversation entry structure from [/types/ollama](../../types/ollama).
+- `ExportFormat` – supported export options from [/types/markdown](../../types/markdown).
+
+## Key Dependencies and Related Modules
+
+- `exportConversation` utility in `src/lib/exportConversation.ts`.
+- UI component `ExportMenu` under `components/chat`.
+- `exportMarkdown` helper for Markdown/HTML/PDF downloads.
+
+## Architecture Diagram
+
+```mermaid
+flowchart TD
+    ChatInterface --> ExportMenu --> exportConversation
+    exportConversation --> exportMarkdown
+```
+
+## Documentation Maintenance
+
+Update this document if new export formats or flows are introduced.

--- a/ollama-ui/components/chat/ChatInterface.tsx
+++ b/ollama-ui/components/chat/ChatInterface.tsx
@@ -4,6 +4,7 @@ import { ChatMessage } from "./ChatMessage";
 import { ChatInput } from "./ChatInput";
 import { useChatStore } from "@/stores/chat-store";
 import { ThemeToggle } from "@/components/ui";
+import { ExportMenu } from "./ExportMenu";
 
 export const ChatInterface = () => {
   const { messages, isStreaming, sendMessage } = useChatStore();
@@ -15,7 +16,8 @@ export const ChatInterface = () => {
 
   return (
     <div className="flex flex-col h-screen">
-      <div className="p-2 border-b flex justify-end">
+      <div className="p-2 border-b flex justify-between items-center">
+        <ExportMenu />
         <ThemeToggle />
       </div>
       <div className="flex-1 overflow-y-auto p-4 flex flex-col gap-2">

--- a/ollama-ui/components/chat/ExportMenu.tsx
+++ b/ollama-ui/components/chat/ExportMenu.tsx
@@ -1,0 +1,38 @@
+"use client";
+import { Download } from "lucide-react";
+import { Button } from "@/components/ui";
+import { useChatStore } from "@/stores/chat-store";
+import { exportConversation } from "@/lib/exportConversation";
+
+export const ExportMenu = () => {
+  const { messages } = useChatStore();
+  if (messages.length === 0) return null;
+  return (
+    <div className="flex gap-2">
+      <Button
+        size="icon"
+        variant="outline"
+        onClick={() => exportConversation(messages, "markdown")}
+        aria-label="Export as Markdown"
+      >
+        <Download className="w-4 h-4" />
+      </Button>
+      <Button
+        size="icon"
+        variant="outline"
+        onClick={() => exportConversation(messages, "pdf")}
+        aria-label="Export as PDF"
+      >
+        <Download className="w-4 h-4" />
+      </Button>
+      <Button
+        size="icon"
+        variant="outline"
+        onClick={() => exportConversation(messages, "json")}
+        aria-label="Export as JSON"
+      >
+        <Download className="w-4 h-4" />
+      </Button>
+    </div>
+  );
+};

--- a/ollama-ui/components/chat/index.ts
+++ b/ollama-ui/components/chat/index.ts
@@ -1,0 +1,5 @@
+export * from "./ChatInput";
+export * from "./ChatInterface";
+export * from "./ChatMessage";
+export * from "./ChatSettings";
+export * from "./ExportMenu";

--- a/ollama-ui/src/lib/exportConversation.ts
+++ b/ollama-ui/src/lib/exportConversation.ts
@@ -1,0 +1,28 @@
+import { ExportFormat } from "@/types";
+import type { ChatMessage } from "@/types";
+import { exportMarkdown } from "./exportMarkdown";
+
+export function exportConversation(
+  messages: ChatMessage[],
+  format: ExportFormat,
+  filename = "conversation"
+): void {
+  const md = messages
+    .map((m) => `### ${m.role}\n${m.content}`)
+    .join("\n\n");
+
+  if (format === "json") {
+    const blob = new Blob([JSON.stringify(messages, null, 2)], {
+      type: "application/json",
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${filename}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+    return;
+  }
+
+  exportMarkdown(md, format, filename);
+}

--- a/types/markdown/ExportFormat.ts
+++ b/types/markdown/ExportFormat.ts
@@ -1,1 +1,1 @@
-export type ExportFormat = "markdown" | "html" | "pdf";
+export type ExportFormat = "markdown" | "html" | "pdf" | "json";


### PR DESCRIPTION
## Summary
- enable JSON format in `ExportFormat`
- add `exportConversation` utility
- export conversations from new `ExportMenu`
- integrate `ExportMenu` into `ChatInterface`
- document export feature
- check off export task in `checklist`

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_684c9801a3b48323b1d88e2a4e831001