### PR TITLE
Expand LangChain integration docs

### DIFF
--- a/lang-checklist.md
+++ b/lang-checklist.md
@@ -1,0 +1,20 @@
+# LangChain Integration Checklist
+
+Use this checklist to track progress while implementing the LangChain pipeline described in `lang-implementation.md`.
+
+- [ ] Install `langchain` dependency within `ollama-ui` and commit the lockfile.
+- [ ] Create `types/langchain` with:
+  - `AgentPipeline.ts`
+  - `RetrieverOptions.ts`
+  - `PromptOptions.ts`
+  - `Tool.ts`
+  - `index.ts` barrel file
+- [ ] Re-export new types from `types/index.ts`.
+- [ ] Implement `OllamaChat` wrapper in `src/lib/langchain/ollama-chat.ts`.
+- [ ] Implement `VectorStoreRetriever` in `src/lib/langchain/vector-retriever.ts`.
+- [ ] Implement `PromptBuilder` in `src/lib/langchain/prompt-builder.ts`.
+- [ ] Create `AgentPipeline` service in `src/services/agent-pipeline.ts` exposing `.use()` for additional steps.
+- [ ] Refactor `useChatStore` to create and run the pipeline instead of calling `OllamaClient` directly.
+- [ ] Add unit tests for wrappers and the pipeline.
+- [ ] Create `docs/langchain/overview.md` and update existing diagrams to include the new pipeline.
+- [ ] Run `pnpm test` and `pnpm build` to verify before opening a PR.

--- a/lang-implementation.md
+++ b/lang-implementation.md
@@ -2,20 +2,21 @@
 
 ## Overview
 
-This expanded document details the integration of [LangChain](https://python.langchain.com/docs/get_started/introduction) into the existing Ollama web application. The goal is to replace the minimal agentic flow with a robust and extensible pipeline capable of supporting complex retrieval, tool usage and future orchestration strategies.
+This document expands on the initial integration notes and describes a full design for bringing [LangChain](https://python.langchain.com/docs/get_started/introduction) into the Ollama web application. The goal is to evolve the existing "agentic" chat mode into a modular pipeline that orchestrates retrieval, prompt assembly, LLM invocation and future tool usage. All design decisions must follow [AGENTS.md](AGENTS.md) and align with the documentation in `docs/`.
 
-The design strictly follows [`AGENTS.md`](AGENTS.md) and references the current architecture in [`docs/agentic-chat/overview.md`](docs/agentic-chat/overview.md) and [`docs/vector-store/overview.md`](docs/vector-store/overview.md).
+LangChain will provide the building blocks for a streaming agent pipeline without impacting the UI components. `useChatStore` remains the orchestrator of conversation state while LangChain handles each step of the workflow.
 
 ## Design Goals
 
-- **Modularity** – each concern (retrieval, prompt construction, LLM call, tool invocation) lives in its own module.
-- **Extensibility** – the pipeline can easily accept new `Runnable` steps such as summarisation tools or external API calls.
-- **Type Safety** – all LangChain-related types will reside under `/types/langchain` and be barrel exported via `/types/index.ts`.
-- **Minimal UI Impact** – existing components remain intact, with `useChatStore` acting purely as an orchestrator.
+- **Modularity** – each step (retrieval, prompt construction, LLM call, tool invocation) is isolated in its own module.
+- **Extensibility** – new `Runnable` steps can be inserted without rewriting existing code. The pipeline exposes hooks for future tools such as summarisation or external APIs.
+- **Type Safety** – all LangChain-related interfaces live under `/types/langchain` and are barrel exported via `/types/index.ts`.
+- **Minimal UI Impact** – existing components remain unchanged; the store simply consumes an async generator from the pipeline.
+- **Streaming** – responses stream through the pipeline so the UI updates in real time.
 
 ## Current Agentic Flow
 
-The current agentic mode retrieves context from a vector database and prepends it to the conversation before calling Ollama. It can be summarised as:
+The present implementation fetches context from the vector store and prepends it to the conversation before sending the request to Ollama.
 
 ```mermaid
 sequenceDiagram
@@ -31,50 +32,41 @@ sequenceDiagram
     Store-->>UI: update messages
 ```
 
-This implementation is functional but difficult to extend. There is no place to insert additional tools or prompts without modifying `chat-store.ts` directly.
+While functional, this flow does not allow additional tools or processing steps without directly modifying `chat-store.ts`.
 
-## Proposed Architecture
+## Target Architecture
 
-LangChain will be introduced through a small set of wrapper classes and a streaming pipeline. The following high‑level diagram shows how the pieces fit together:
+LangChain introduces a streaming pipeline that composes small `Runnable` units. Each unit focuses on a single responsibility and can be replaced or reordered. The high-level architecture is shown below.
 
 ```mermaid
 flowchart TD
     subgraph Stores
-        D[ChatStore]
+        S[useChatStore]
     end
     subgraph Services
-        C[AgentPipeline]
+        P[AgentPipeline]
     end
     subgraph LangChain
-        A[OllamaChat\n(BaseChatModel)]
-        B[VectorStoreRetriever\n(Retriever)]
+        RC[VectorStoreRetriever]
+        PR[PromptBuilder]
+        OC[OllamaChat]
     end
-    D -- messages --> C
-    C --> B
-    B --> VectorStoreService
-    C --> A
-    A --> OllamaClient
+    S -- messages --> P
+    P --> RC
+    RC --> VectorStoreService
+    P --> PR
+    PR --> OC
+    OC --> OllamaClient
 ```
 
-### Key Modules
+### Pipeline Steps
 
-1. **OllamaChat** (`src/lib/langchain/ollama-chat.ts`)
-   - Implements the LangChain `BaseChatModel` interface.
-   - Wraps `OllamaClient.chat()` and yields `ChatResponse` chunks.
-   - Respects settings from [`/types/ollama`](types/ollama).
-2. **VectorStoreRetriever** (`src/lib/langchain/vector-retriever.ts`)
-   - Implements LangChain's `Retriever` interface.
-   - Uses `VectorStoreService.search()`.
-   - Operates on `Document`, `SearchResult` and `SearchFilters` from [`/types/vector`](types/vector).
-3. **AgentPipeline** (`src/services/agent-pipeline.ts`)
-   - Factory function `createAgentPipeline(settings: ChatSettings)`.
-   - Returns a `RunnableSequence` which:
-     1. Retrieves documents using `VectorStoreRetriever`.
-     2. Formats a prompt with conversation history (`Message` from [`/types/chat`](types/chat)).
-     3. Streams completion chunks via `OllamaChat`.
-   - Future tools can be inserted as additional `Runnable` steps without touching the store or UI.
+1. **VectorStoreRetriever** – fetches relevant documents.
+2. **PromptBuilder** – assembles conversation history and retrieved documents into the final prompt.
+3. **OllamaChat** – streams completion chunks from the Ollama API.
+4. **Tool Steps (optional)** – custom tools can be inserted anywhere in the pipeline via LangChain's `RunnableSequence`.
 
-### Data Flow
+### Sequence with Optional Tools
 
 ```mermaid
 sequenceDiagram
@@ -83,21 +75,35 @@ sequenceDiagram
     participant Store as useChatStore
     participant Pipeline as AgentPipeline
     participant Retriever as VectorStoreRetriever
+    participant Prompt as PromptBuilder
     participant LLM as OllamaChat
     User->>UI: submit message
     UI->>Store: sendMessage(text)
     Store->>Pipeline: run(messages)
     Pipeline->>Retriever: retrieve(text)
     Retriever-->>Pipeline: docs[]
-    Pipeline->>LLM: invoke(history + docs)
+    Pipeline->>Prompt: build(history + docs)
+    Prompt-->>Pipeline: prompt
+    Pipeline->>LLM: invoke(prompt)
     LLM-->>Pipeline: ChatResponse*
     Pipeline-->>Store: stream chunks
     Store-->>UI: update chat
 ```
 
-## New Types
+## Module Breakdown
 
-All new types will be placed under `types/langchain` and barrel exported from `types/index.ts`.
+| Module | Path | Responsibility |
+| ------ | ---- | -------------- |
+| `OllamaChat` | `src/lib/langchain/ollama-chat.ts` | Implements `BaseChatModel` and wraps `OllamaClient.chat` for streaming. |
+| `VectorStoreRetriever` | `src/lib/langchain/vector-retriever.ts` | Adapter implementing LangChain's `Retriever` interface using `VectorStoreService`. |
+| `PromptBuilder` | `src/lib/langchain/prompt-builder.ts` | Constructs prompts from chat history, retrieved docs and `ChatSettings`. |
+| `AgentPipeline` | `src/services/agent-pipeline.ts` | Factory producing a `RunnableSequence` composed of the above steps plus optional tools. |
+
+Additional tools can live under `src/lib/langchain/tools/` and be composed into the pipeline without altering the store.
+
+## Type Definitions
+
+All types reside under `types/langchain`:
 
 ```typescript
 // types/langchain/AgentPipeline.ts
@@ -110,46 +116,76 @@ export interface RetrieverOptions {
   filters?: SearchFilters;
   topK?: number;
 }
+
+// types/langchain/PromptOptions.ts
+export interface PromptOptions {
+  systemPrompt?: string;
+}
+
+// types/langchain/Tool.ts
+export interface Tool {
+  name: string;
+  invoke(input: string): Promise<string>;
+}
 ```
 
-These interfaces formalise how the pipeline and retrievers operate, ensuring future tools follow consistent patterns.
+These interfaces ensure a consistent contract for pipeline steps and future tools.
 
-## Step-by-Step Integration
+## Extending the Pipeline
 
-1. **Dependency Setup**
-   - `pnpm add langchain` within `ollama-ui`.
-   - Update lockfile and commit.
-2. **Scaffold Types**
-   - Create `types/langchain` with `AgentPipeline.ts`, `RetrieverOptions.ts` and an `index.ts` barrel file.
-   - Export from the root `types/index.ts`.
-3. **LangChain Wrappers**
-   - Implement `OllamaChat` and `VectorStoreRetriever` using the types defined above.
-   - Ensure all methods return Promises or async generators.
-4. **Agent Pipeline Service**
-   - Build `createAgentPipeline(settings: ChatSettings)` returning an object matching `AgentPipeline`.
-   - Compose a `RunnableSequence` with retrieval and LLM invocation.
-   - Provide hooks to append additional `Runnable` steps.
-5. **Store Refactor**
-   - Update `useChatStore.sendMessage` to instantiate the pipeline and consume its stream.
-   - Remove direct calls to `VectorStoreService` and `OllamaClient` from the store.
-6. **Documentation**
-   - Create `docs/langchain/overview.md` summarising the architecture, referencing this file and all related types.
-   - Update diagrams in `docs/agentic-chat/overview.md` to include the new pipeline.
-7. **Testing & Build**
-   - Add unit tests for `OllamaChat` and `VectorStoreRetriever` under `ollama-ui`.
-   - Run `pnpm test` and `pnpm build` to verify integration.
+The `createAgentPipeline` factory exposes a simple API for adding new `Runnable` steps:
 
-## Checklist Before Implementation
+```typescript
+const pipeline = createAgentPipeline(settings)
+  .use(new VectorStoreRetriever(opts))
+  .use(new PromptBuilder())
+  .use(myCustomTool)
+  .use(new OllamaChat(settings));
+```
 
-- [ ] Install LangChain and commit lockfile updates.
-- [ ] Add `/types/langchain` with barrel exports.
-- [ ] Implement `OllamaChat` wrapper.
+Each call to `.use()` returns a new sequence with the additional step. The resulting pipeline yields `ChatResponse` chunks that the store forwards to the UI. Tools can transform the input or output of any step, making the system easy to extend.
+
+## Implementation Steps
+
+1. **Install Dependencies**
+   - Run `pnpm add langchain` inside `ollama-ui`.
+   - Commit the updated lockfile.
+2. **Add Type Definitions**
+   - Create `/types/langchain` with the interfaces shown above and an `index.ts` barrel file.
+   - Re-export these types from the root `types/index.ts`.
+3. **Create LangChain Wrappers**
+   - Implement `OllamaChat` to conform to `BaseChatModel` and stream `ChatResponse` chunks.
+   - Implement `VectorStoreRetriever` using `VectorStoreService.search`.
+   - Implement `PromptBuilder` for assembling prompts.
+4. **Build AgentPipeline Service**
+   - `createAgentPipeline(settings: ChatSettings)` returns an object implementing `AgentPipeline`.
+   - Compose steps using LangChain's `RunnableSequence`.
+   - Provide a `.use(step: Runnable)` method for inserting tools.
+5. **Refactor useChatStore**
+   - Replace the existing agentic logic with a call to `pipeline.run(messages)`.
+   - Stream chunks into the message list as they arrive.
+6. **Documentation Updates**
+   - Add `docs/langchain/overview.md` summarising this architecture with diagrams.
+   - Update `docs/agentic-chat/overview.md` to reference the new pipeline design.
+7. **Testing**
+   - Create unit tests for each wrapper and the pipeline builder.
+   - Ensure vector search and streaming behaviour work as expected.
+8. **Build Verification**
+   - Run `pnpm test` and `pnpm build` before merging any code changes.
+
+## Checklist
+
+- [ ] Install LangChain dependency.
+- [ ] Add `/types/langchain` with `AgentPipeline`, `RetrieverOptions`, `PromptOptions` and `Tool` definitions.
+- [ ] Implement `OllamaChat` wrapper with streaming support.
 - [ ] Implement `VectorStoreRetriever` wrapper.
-- [ ] Create `AgentPipeline` service with insertion points for tools.
-- [ ] Refactor `useChatStore` to use the pipeline.
-- [ ] Update `docs/langchain/overview.md` and refresh diagrams across documentation.
-- [ ] Ensure `pnpm build` and `pnpm test` succeed.
+- [ ] Implement `PromptBuilder`.
+- [ ] Create `AgentPipeline` service exposing `.use()` for additional tools.
+- [ ] Refactor `useChatStore` to consume the pipeline.
+- [ ] Document the architecture under `docs/langchain` and update existing diagrams.
+- [ ] Add unit tests for new modules.
+- [ ] Verify with `pnpm test` and `pnpm build`.
 
 ## Summary
 
-By introducing LangChain as an orchestration layer, we separate retrieval, prompt construction and model invocation into clearly defined modules. The architecture allows new tools or advanced planning to be added without disrupting the UI or existing services. Following the above checklist will lead to a modular and easily extensible system that integrates smoothly with the current codebase.
+This plan introduces LangChain as a flexible orchestration layer while keeping the UI untouched. By isolating retrieval, prompt generation and LLM calls into independent steps we gain a clear extension point for future tools. The provided types and modular pipeline ensure that additional capabilities can be integrated with minimal friction.


### PR DESCRIPTION
## Summary
- expand `lang-implementation.md` with more details, diagrams, and modular design guidance
- add new checklist `lang-checklist.md` for implementation tasks

## Testing
- `pnpm exec vitest run`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684cbd3fc8848323934f5dd47639c066