### PR TITLE
Add langchain types and wrappers

### DIFF
--- a/lang-checklist.md
+++ b/lang-checklist.md
@@ -3,16 +3,16 @@
 Use this checklist to track progress while implementing the LangChain pipeline described in `lang-implementation.md`.
 
 - [x] Install `langchain` dependency within `ollama-ui`.
-- [ ] Create `types/langchain` with:
+- [x] Create `types/langchain` with:
   - `AgentPipeline.ts`
   - `RetrieverOptions.ts`
   - `PromptOptions.ts`
   - `Tool.ts`
   - `index.ts` barrel file
-- [ ] Re-export new types from `types/index.ts`.
-- [ ] Implement `OllamaChat` wrapper in `src/lib/langchain/ollama-chat.ts`.
-- [ ] Implement `VectorStoreRetriever` in `src/lib/langchain/vector-retriever.ts`.
-- [ ] Implement `PromptBuilder` in `src/lib/langchain/prompt-builder.ts`.
+- [x] Re-export new types from `types/index.ts`.
+- [x] Implement `OllamaChat` wrapper in `src/lib/langchain/ollama-chat.ts`.
+- [x] Implement `VectorStoreRetriever` in `src/lib/langchain/vector-retriever.ts`.
+- [x] Implement `PromptBuilder` in `src/lib/langchain/prompt-builder.ts`.
 - [ ] Create `AgentPipeline` service in `src/services/agent-pipeline.ts` exposing `.use()` for additional steps.
 - [ ] Refactor `useChatStore` to create and run the pipeline instead of calling `OllamaClient` directly.
 - [ ] Add unit tests for wrappers and the pipeline.

--- a/ollama-ui/src/lib/langchain/ollama-chat.ts
+++ b/ollama-ui/src/lib/langchain/ollama-chat.ts
@@ -1,0 +1,18 @@
+import type { ChatRequest, ChatResponse, ChatSettings } from "@/types";
+import { OllamaClient } from "@/lib/ollama/client";
+
+export class OllamaChat {
+  private client: OllamaClient;
+
+  constructor(private settings: ChatSettings & { baseUrl?: string }) {
+    this.client = new OllamaClient({
+      baseUrl: settings.baseUrl || "http://localhost:11434",
+    });
+  }
+
+  async *invoke(request: ChatRequest): AsyncGenerator<ChatResponse> {
+    for await (const chunk of this.client.chat(request)) {
+      yield chunk;
+    }
+  }
+}

--- a/ollama-ui/src/lib/langchain/prompt-builder.ts
+++ b/ollama-ui/src/lib/langchain/prompt-builder.ts
@@ -1,0 +1,11 @@
+import type { Message, PromptOptions } from "@/types";
+
+export class PromptBuilder {
+  constructor(private opts?: PromptOptions) {}
+
+  build(messages: Message[]): string {
+    const system = this.opts?.systemPrompt;
+    const history = messages.map((m) => `${m.role}: ${m.content}`).join("\n");
+    return [system, history].filter(Boolean).join("\n");
+  }
+}

--- a/ollama-ui/src/lib/langchain/vector-retriever.ts
+++ b/ollama-ui/src/lib/langchain/vector-retriever.ts
@@ -1,0 +1,10 @@
+import type { RetrieverOptions, SearchResult } from "@/types";
+import { vectorStore } from "@/lib/vector";
+
+export class VectorStoreRetriever {
+  constructor(private options?: RetrieverOptions) {}
+
+  async getRelevantDocuments(query: string): Promise<SearchResult[]> {
+    return vectorStore.search(query, this.options?.filters);
+  }
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -4,3 +4,4 @@ export * from "./chat";
 
 export * from "./settings";
 export * from "./vector";
+export * from "./langchain";

--- a/types/langchain/AgentPipeline.ts
+++ b/types/langchain/AgentPipeline.ts
@@ -1,0 +1,5 @@
+import type { Message, ChatResponse } from "../";
+
+export interface AgentPipeline {
+  run(messages: Message[]): AsyncGenerator<ChatResponse>;
+}

--- a/types/langchain/PromptOptions.ts
+++ b/types/langchain/PromptOptions.ts
@@ -1,0 +1,3 @@
+export interface PromptOptions {
+  systemPrompt?: string;
+}

--- a/types/langchain/RetrieverOptions.ts
+++ b/types/langchain/RetrieverOptions.ts
@@ -1,0 +1,6 @@
+import type { SearchFilters } from "../";
+
+export interface RetrieverOptions {
+  filters?: SearchFilters;
+  topK?: number;
+}

--- a/types/langchain/Tool.ts
+++ b/types/langchain/Tool.ts
@@ -1,0 +1,4 @@
+export interface Tool {
+  name: string;
+  invoke(input: string): Promise<string>;
+}

--- a/types/langchain/index.ts
+++ b/types/langchain/index.ts
@@ -1,0 +1,4 @@
+export * from "./AgentPipeline";
+export * from "./RetrieverOptions";
+export * from "./PromptOptions";
+export * from "./Tool";


### PR DESCRIPTION
## Summary
- stub langchain pipeline types
- add basic langchain wrappers for Ollama chat, vector retrieval, and prompt building
- export new types via barrel files
- update checklist for completed tasks

## Testing
- `pnpm test -- --run`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684cd21ed5f88323be40e5cee13e1853