### PR TITLE
Add abortable agent pipeline with UI feedback

### DIFF
--- a/lang-checklist.md
+++ b/lang-checklist.md
@@ -18,14 +18,15 @@ Use this checklist to track progress while implementing the LangChain pipeline d
 - [x] Refactor `useChatStore` to create and run the pipeline instead of calling `OllamaClient` directly.
 - [x] Add unit tests for wrappers and the pipeline.
 - [x] Create `docs/langchain/overview.md` and update existing diagrams to include the new pipeline.
-- [ ] Run `pnpm test` and `pnpm build` to verify before opening a PR.
+- [x] Run `pnpm test` and `pnpm build` to verify before opening a PR.
 
 ## Progress Notes
 - Implemented embedder, reranker, and RAG assembler modules.
 - Refactored useChatStore to run createAgentPipeline.
-- Next: add unit tests and update documentation.
-
-Progress: Implemented embedding and reranking services. Refactored useChatStore to use LangChain pipeline.
 - Added progress notifier feature with status updates in UI.
 - Added error handling for retriever and chat invocation.
-- Build succeeds but tests currently fail.
+- Build and tests succeed.
+
+Latest: Added abortable pipeline with stop control and spinner feedback. Added
+RagAssembler error handling and pipeline guard. All tests pass and build
+verified.

--- a/ollama-ui/components/chat/ChatInput.tsx
+++ b/ollama-ui/components/chat/ChatInput.tsx
@@ -4,9 +4,10 @@ import { Button } from "@/components/ui/button";
 
 interface ChatInputProps {
   onSend: (text: string) => void;
+  disabled?: boolean;
 }
 
-export const ChatInput = ({ onSend }: ChatInputProps) => {
+export const ChatInput = ({ onSend, disabled }: ChatInputProps) => {
   const [text, setText] = useState("");
 
   return (
@@ -23,9 +24,12 @@ export const ChatInput = ({ onSend }: ChatInputProps) => {
         className="flex-1 rounded border p-2"
         value={text}
         onChange={(e) => setText(e.target.value)}
+        disabled={disabled}
         rows={1}
       />
-      <Button type="submit">Send</Button>
+      <Button type="submit" disabled={disabled}>
+        Send
+      </Button>
     </form>
   );
 };

--- a/ollama-ui/components/chat/ChatInterface.tsx
+++ b/ollama-ui/components/chat/ChatInterface.tsx
@@ -3,12 +3,13 @@ import { useEffect, useRef } from "react";
 import { ChatMessage } from "./ChatMessage";
 import { ChatInput } from "./ChatInput";
 import { useChatStore } from "@/stores/chat-store";
-import { ThemeToggle, Badge } from "@/components/ui";
+import { ThemeToggle, Badge, Button, Spinner } from "@/components/ui";
 import { ExportMenu } from "./ExportMenu";
 import { AgentStatus } from "./AgentStatus";
 
 export const ChatInterface = () => {
-  const { messages, isStreaming, sendMessage, mode, status } = useChatStore();
+  const { messages, isStreaming, sendMessage, stop, mode, status } =
+    useChatStore();
   const bottomRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -23,7 +24,17 @@ export const ChatInterface = () => {
           <Badge>{mode} mode</Badge>
         </div>
         <div className="flex items-center gap-2">
-          {status && <span className="text-xs italic text-gray-500">{status}</span>}
+          {status && (
+            <span className="text-xs italic text-gray-500 flex items-center gap-1">
+              {isStreaming && <Spinner className="w-3 h-3" />}
+              {status}
+            </span>
+          )}
+          {isStreaming && (
+            <Button variant="outline" size="icon" onClick={stop}>
+              Stop
+            </Button>
+          )}
           <ThemeToggle />
         </div>
       </div>
@@ -35,7 +46,7 @@ export const ChatInterface = () => {
         <AgentStatus />
         <div ref={bottomRef} />
       </div>
-      <ChatInput onSend={sendMessage} />
+      <ChatInput onSend={sendMessage} disabled={isStreaming} />
     </div>
   );
 };

--- a/ollama-ui/components/ui/index.ts
+++ b/ollama-ui/components/ui/index.ts
@@ -4,3 +4,4 @@ export * from "./card";
 export * from "./ErrorBoundary";
 export * from "./ThemeProvider";
 export * from "./ThemeToggle";
+export * from "./spinner";

--- a/ollama-ui/components/ui/spinner.tsx
+++ b/ollama-ui/components/ui/spinner.tsx
@@ -1,0 +1,22 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export const Spinner = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("animate-spin", className)} {...props}>
+    <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none">
+      <circle
+        className="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="4"
+      />
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+      />
+    </svg>
+  </div>
+);

--- a/ollama-ui/src/lib/langchain/__tests__/AgentPipeline.test.ts
+++ b/ollama-ui/src/lib/langchain/__tests__/AgentPipeline.test.ts
@@ -17,9 +17,19 @@ vi.mock('../../../services/reranker-service', () => ({
 
 describe('AgentPipeline', () => {
   it('runs pipeline', async () => {
-    const pipeline = createAgentPipeline({ temperature: 0, maxTokens: 0, systemPrompt: '' });
+    const pipeline = createAgentPipeline({
+      temperature: 0,
+      maxTokens: 0,
+      systemPrompt: '',
+    });
     const iter = pipeline.run([]);
-    const { value } = await iter.next();
-    expect(value?.message).toBe('hello');
+    let result: string | undefined;
+    for await (const out of iter) {
+      if (out.type === 'chat') {
+        result = out.chunk.message;
+        break;
+      }
+    }
+    expect(result).toBe('hello');
   });
 });

--- a/ollama-ui/src/lib/langchain/rag-assembler.ts
+++ b/ollama-ui/src/lib/langchain/rag-assembler.ts
@@ -2,11 +2,16 @@ import type { Message, SearchResult } from "@/types";
 
 export class RagAssembler {
   assemble(messages: Message[], docs: SearchResult[]): Message[] {
-    const systemMessages = docs.map((d) => ({
-      id: crypto.randomUUID(),
-      role: "system" as const,
-      content: d.text,
-    }));
-    return [...messages, ...systemMessages];
+    try {
+      const systemMessages = docs.map((d) => ({
+        id: crypto.randomUUID(),
+        role: "system" as const,
+        content: d.text,
+      }));
+      return [...messages, ...systemMessages];
+    } catch (error) {
+      console.error("RagAssembler error", error);
+      return messages;
+    }
   }
 }

--- a/ollama-ui/stores/chat-store.ts
+++ b/ollama-ui/stores/chat-store.ts
@@ -11,21 +11,30 @@ interface ChatState {
   messages: Message[];
   isStreaming: boolean;
   status: string | null;
+  abortController: AbortController | null;
   mode: ChatMode;
   setMode: (mode: ChatMode) => void;
   sendMessage: (text: string) => Promise<void>;
+  stop: () => void;
 }
 
 export const useChatStore = create<ChatState>((set, get) => ({
   messages: [],
   isStreaming: false,
   status: null,
+  abortController: null,
   mode: "simple",
   setMode: (mode) => set({ mode }),
   async sendMessage(text: string) {
     const userMsg: Message = { id: crypto.randomUUID(), role: "user", content: text };
     const current = get().messages;
-    set({ messages: [...current, userMsg], isStreaming: true, status: null });
+    const controller = new AbortController();
+    set({
+      messages: [...current, userMsg],
+      isStreaming: true,
+      status: null,
+      abortController: controller,
+    });
 
     const {
       vectorStorePath,
@@ -45,19 +54,26 @@ export const useChatStore = create<ChatState>((set, get) => ({
       });
       let assistant: Message = { id: crypto.randomUUID(), role: "assistant", content: "" };
       set((state) => ({ messages: [...state.messages, assistant] }));
-      for await (const out of pipeline.run([...current, userMsg])) {
-        if (out.type === "status") {
-          set({ status: out.message });
-          continue;
+      try {
+        for await (const out of pipeline.run([...current, userMsg], controller.signal)) {
+          if (out.type === "status") {
+            set({ status: out.message });
+            if (controller.signal.aborted) return;
+            continue;
+          }
+          assistant = { ...assistant, content: assistant.content + out.chunk.message };
+          set((state) => {
+            const msgs = [...state.messages];
+            msgs[msgs.length - 1] = assistant;
+            return { messages: msgs };
+          });
+          if (controller.signal.aborted) return;
         }
-        assistant = { ...assistant, content: assistant.content + out.chunk.message };
-        set((state) => {
-          const msgs = [...state.messages];
-          msgs[msgs.length - 1] = assistant;
-          return { messages: msgs };
-        });
+      } catch (error) {
+        console.error("Pipeline run failed", error);
+        set({ status: "Unexpected error" });
       }
-      set({ isStreaming: false, status: null });
+      set({ isStreaming: false, status: null, abortController: null });
       return;
     }
 
@@ -77,8 +93,11 @@ export const useChatStore = create<ChatState>((set, get) => ({
         return { messages: msgs };
       });
     }
-
-    set({ isStreaming: false, status: null });
+    set({ isStreaming: false, status: null, abortController: null });
+  },
+  stop() {
+    get().abortController?.abort();
+    set({ isStreaming: false, status: null, abortController: null });
   },
 }));
 


### PR DESCRIPTION
## Summary
- implement abortable pipeline execution via AbortController
- add spinner component and stop button to chat UI
- disable chat input during streaming
- improve error handling in RagAssembler and pipeline run
- update AgentPipeline test and docs checklist

## Testing
- `pnpm exec vitest run`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684d0bc76d3883239b58b55faec0ee51