### PR TITLE
Implement summarizer and enhanced error feedback

### DIFF
--- a/docs/langchain/overview.md
+++ b/docs/langchain/overview.md
@@ -2,7 +2,7 @@
 
 ## Feature Purpose and Scope
 
-Provide a modular pipeline for retrieval augmented generation (RAG) using LangChain. The pipeline handles embeddings, vector search, reranking and prompt assembly before streaming results from Ollama. Each step emits progress events so the UI can display the agent's current action. A separate "thinking" output exposes a short summary of the pipeline's reasoning which can be expanded in the chat UI.
+Provide a modular pipeline for retrieval augmented generation (RAG) using LangChain. The pipeline handles embeddings, vector search, reranking and prompt assembly before streaming results from Ollama. Each step emits progress events so the UI can display the agent's current action. A separate "thinking" output exposes a short summary of the pipeline's reasoning which can be expanded in the chat UI. After the model responds, a lightweight summariser step generates a short overview for quick reference.
 
 ## Core Flows and UI Touchpoints
 
@@ -31,6 +31,7 @@ flowchart TD
         RR[RerankerService]
         P[PromptBuilder]
         C[OllamaChat]
+        S[ResponseSummariser]
     end
-    Q --> E --> R --> RR --> P --> C
+    Q --> E --> R --> RR --> P --> C --> S
 ```

--- a/lang-checklist.md
+++ b/lang-checklist.md
@@ -31,3 +31,4 @@ Progress: Implemented embedding and reranking services. Refactored useChatStore 
 - Build succeeds but tests currently fail.
 - Added "thinking" output event and UI panel.
 - Added safeguards for empty queries and tool failures.
+- Added summariser step with UI summary panel. Enhanced error events for retrieval and model invocation.

--- a/ollama-ui/components/chat/AgentError.tsx
+++ b/ollama-ui/components/chat/AgentError.tsx
@@ -1,0 +1,8 @@
+"use client";
+import { useChatStore } from "@/stores/chat-store";
+
+export const AgentError = () => {
+  const error = useChatStore((s) => s.error);
+  if (!error) return null;
+  return <p className="text-xs text-red-500 px-2">Error: {error}</p>;
+};

--- a/ollama-ui/components/chat/AgentSummary.tsx
+++ b/ollama-ui/components/chat/AgentSummary.tsx
@@ -1,0 +1,8 @@
+"use client";
+import { useChatStore } from "@/stores/chat-store";
+
+export const AgentSummary = () => {
+  const summary = useChatStore((s) => s.summary);
+  if (!summary) return null;
+  return <p className="text-xs text-gray-600 px-2">Summary: {summary}</p>;
+};

--- a/ollama-ui/components/chat/ChatInterface.tsx
+++ b/ollama-ui/components/chat/ChatInterface.tsx
@@ -7,6 +7,8 @@ import { ThemeToggle, Badge } from "@/components/ui";
 import { ExportMenu } from "./ExportMenu";
 import { AgentStatus } from "./AgentStatus";
 import { AgentThinking } from "./AgentThinking";
+import { AgentSummary } from "./AgentSummary";
+import { AgentError } from "./AgentError";
 
 export const ChatInterface = () => {
   const { messages, isStreaming, sendMessage, mode, status } = useChatStore();
@@ -35,6 +37,8 @@ export const ChatInterface = () => {
         {isStreaming && <ChatMessage message={{ role: "assistant", content: "" }} />}
         <AgentStatus />
         <AgentThinking />
+        <AgentError />
+        <AgentSummary />
         <div ref={bottomRef} />
       </div>
       <ChatInput onSend={sendMessage} />

--- a/ollama-ui/components/chat/index.ts
+++ b/ollama-ui/components/chat/index.ts
@@ -5,3 +5,5 @@ export * from "./ChatSettings";
 export * from "./ExportMenu";
 export * from "./AgentStatus";
 export * from "./AgentThinking";
+export * from "./AgentSummary";
+export * from "./AgentError";

--- a/ollama-ui/src/lib/langchain/__tests__/AgentPipeline.test.ts
+++ b/ollama-ui/src/lib/langchain/__tests__/AgentPipeline.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { createAgentPipeline } from '../../../services/agent-pipeline';
+import type { PipelineOutput } from '@/types';
 
 vi.mock('../vector-retriever', () => ({
   VectorStoreRetriever: class {
@@ -18,7 +19,7 @@ vi.mock('../../../services/reranker-service', () => ({
 describe('AgentPipeline', () => {
   it('runs pipeline', async () => {
     const pipeline = createAgentPipeline({ temperature: 0, maxTokens: 0, systemPrompt: '' });
-    const outputs = [] as any[];
+    const outputs: PipelineOutput[] = [];
     for await (const out of pipeline.run([{ id: '1', role: 'user', content: 'hi' }])) {
       outputs.push(out);
     }
@@ -26,5 +27,7 @@ describe('AgentPipeline', () => {
     expect(chat.chunk.message).toBe('hello');
     const thinking = outputs.find(o => o.type === 'thinking');
     expect(thinking).toBeTruthy();
+    const summary = outputs.find(o => o.type === 'summary');
+    expect(summary).toBeTruthy();
   });
 });

--- a/ollama-ui/src/lib/langchain/response-summarizer.ts
+++ b/ollama-ui/src/lib/langchain/response-summarizer.ts
@@ -1,0 +1,6 @@
+export class ResponseSummarizer {
+  summarize(text: string): string {
+    const first = text.split(/\n|\./)[0] || "";
+    return first.trim().slice(0, 100);
+  }
+}

--- a/types/langchain/PipelineOutput.ts
+++ b/types/langchain/PipelineOutput.ts
@@ -1,4 +1,6 @@
 export type PipelineOutput =
   | { type: "status"; message: string }
   | { type: "thinking"; message: string }
-  | { type: "chat"; chunk: import("../ollama").ChatResponse };
+  | { type: "chat"; chunk: import("../ollama").ChatResponse }
+  | { type: "summary"; message: string }
+  | { type: "error"; message: string };


### PR DESCRIPTION
## Summary
- extend PipelineOutput with `summary` and `error` message types
- implement `ResponseSummarizer` and integrate into agent pipeline
- emit error events for retrieval and model invocation
- track summary and error in chat store and display via new components
- document summariser step in LangChain overview
- update tests for new summary output

## Testing
- `pnpm exec vitest run`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684d11308ff48323905c82d7b67317b1