### PR TITLE
Implement markdown prompt instructions

### DIFF
--- a/checklist.md
+++ b/checklist.md
@@ -22,7 +22,7 @@ For recommended system prompts that produce advanced markdown features, see [doc
 - [x] Vector database integration
 - [x] Agentic chat mode
 - [x] Advanced search and filtering
-- [ ] LLM prompt tuning for markdown usage
+- [x] LLM prompt tuning for markdown usage
 - [ ] Performance optimizations
 
 ### Phase 4: Polish & Launch (Weeks 13-16)

--- a/docs/markdown/overview.md
+++ b/docs/markdown/overview.md
@@ -83,6 +83,16 @@ This section can be toggled.
 
 [^note]: This footnote renders at the bottom of the message.
 
+## Default Prompt Instructions
+
+The LangChain pipeline automatically prepends these instructions to every
+conversation so the model outputs rich markdown:
+
+- Use the blockquote syntax with **TIP**, **INFO** or **WARNING** for callouts.
+- Separate files in multi-file examples with `---` lines and specify the
+  language and filename for each code block.
+- Produce diagrams in `mermaid` fenced blocks.
+
 ## Maintaining Documentation
 
 Keep this documentation updated as new markdown capabilities are added in `components/markdown`.

--- a/ollama-ui/src/lib/langchain/__tests__/PromptBuilder.test.ts
+++ b/ollama-ui/src/lib/langchain/__tests__/PromptBuilder.test.ts
@@ -7,4 +7,10 @@ describe('PromptBuilder', () => {
     const prompt = pb.build([{ id: '1', role: 'user', content: 'hi' }]);
     expect(prompt.startsWith('sys')).toBe(true);
   });
+
+  it('includes instructions', () => {
+    const pb = new PromptBuilder({ instructions: ['one', 'two'] });
+    const prompt = pb.build([{ id: '1', role: 'user', content: 'hi' }]);
+    expect(prompt.startsWith('one\ntwo')).toBe(true);
+  });
 });

--- a/ollama-ui/src/lib/markdown-prompts.ts
+++ b/ollama-ui/src/lib/markdown-prompts.ts
@@ -1,0 +1,5 @@
+export const MARKDOWN_INSTRUCTIONS = [
+  'Use the blockquote syntax (>) with TIP, INFO, or WARNING for callout boxes.',
+  'For multi-file examples, separate files with a line containing three dashes (---) and begin each file with a fenced code block specifying the language and filename.',
+  'Create diagrams with mermaid fenced blocks.'
+];

--- a/ollama-ui/stores/chat-store.ts
+++ b/ollama-ui/stores/chat-store.ts
@@ -4,6 +4,7 @@ import { OllamaClient } from "@/lib/ollama/client";
 import { vectorStore } from "@/lib/vector";
 import { createAgentPipeline } from "@/services/agent-pipeline";
 import { useSettingsStore } from "./settings-store";
+import { MARKDOWN_INSTRUCTIONS } from "@/lib/markdown-prompts";
 
 type ChatMode = "simple" | "agentic";
 
@@ -55,6 +56,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
         ...chatSettings,
         embeddingModel,
         rerankingModel,
+        promptOptions: { instructions: MARKDOWN_INSTRUCTIONS },
       });
       let assistant: Message = { id: crypto.randomUUID(), role: "assistant", content: "" };
       set((state) => ({ messages: [...state.messages, assistant] }));


### PR DESCRIPTION
## Summary
- add default advanced markdown instructions
- pass instructions to AgentPipeline
- document the default instructions
- extend PromptBuilder tests
- mark checklist item complete

## Testing
- `pnpm test -- --run`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_684d2e5e45588323b13fc7703fcdbece