### PR TITLE
Enhance markdown prompt instructions

### DIFF
--- a/docs/markdown/overview.md
+++ b/docs/markdown/overview.md
@@ -88,10 +88,13 @@ This section can be toggled.
 The LangChain pipeline automatically prepends these instructions to every
 conversation so the model outputs rich markdown:
 
-- Use the blockquote syntax with **TIP**, **INFO** or **WARNING** for callouts.
+- Use the blockquote syntax with **TIP**, **INFO**, **WARNING**, or **NOTE** for callouts.
 - Separate files in multi-file examples with `---` lines and specify the
   language and filename for each code block.
 - Produce diagrams in `mermaid` fenced blocks.
+- Wrap optional explanations in `<details>` blocks with a `<summary>` title.
+- Reference sources using footnotes.
+- Highlight important lines in code blocks with `{highlight: [n]}` metadata.
 
 ## Maintaining Documentation
 

--- a/docs/markdown/prompt-guidelines.md
+++ b/docs/markdown/prompt-guidelines.md
@@ -3,7 +3,7 @@
 These guidelines explain how system prompts should direct the LLM to output markdown that the application can render with rich features.
 
 ## Callouts
-- Use the standard blockquote syntax (`>`) and prefix with **TIP**, **INFO**, or **WARNING** to create callout boxes.
+- Use the standard blockquote syntax (`>`) and prefix with **TIP**, **INFO**, **WARNING**, or **NOTE** to create callout boxes.
 - Example:
   ```markdown
   > **TIP**: Remember to check your API key.
@@ -31,5 +31,33 @@ These guidelines explain how system prompts should direct the LLM to output mark
       A --> B
   ```
   ```
+
+## Collapsible Sections
+- Wrap optional content in `<details>` with a `<summary>` title so it can be collapsed.
+```markdown
+<details>
+<summary>More info</summary>
+
+Hidden text
+
+</details>
+```
+
+## Footnotes
+- Use GitHub footnote syntax to reference sources.
+```markdown
+Here is a fact.[^1]
+
+[^1]: Source citation.
+```
+
+## Code Line Highlighting
+- Emphasize lines using the `{highlight: [n]}` metadata on fenced code blocks.
+```markdown
+```ts {highlight: [2]}
+const a = 1;
+const b = 2;
+```
+```
 
 See the [overview](./overview.md) for component details.

--- a/ollama-ui/src/lib/markdown-prompts.ts
+++ b/ollama-ui/src/lib/markdown-prompts.ts
@@ -1,5 +1,8 @@
 export const MARKDOWN_INSTRUCTIONS = [
-  'Use the blockquote syntax (>) with TIP, INFO, or WARNING for callout boxes.',
+  'Use the blockquote syntax (>) with TIP, INFO, WARNING or NOTE for callout boxes.',
   'For multi-file examples, separate files with a line containing three dashes (---) and begin each file with a fenced code block specifying the language and filename.',
-  'Create diagrams with mermaid fenced blocks.'
+  'Create diagrams with mermaid fenced blocks.',
+  'Wrap optional sections in <details> with a <summary> title for collapsible content.',
+  'Reference sources using GitHub footnote syntax.',
+  'Highlight key lines in code blocks with {highlight: [n]} metadata.'
 ];


### PR DESCRIPTION
## Summary
- expand MARKDOWN_INSTRUCTIONS with collapsible sections, footnotes and line highlighting
- document new guidelines in prompt-guidelines
- update default prompt list in markdown overview

## Testing
- `pnpm test -- --run`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_684d406833d88323bd9b29592cb638ac