### PR TITLE
Implement Stage 2: Accessibility Audit

### DIFF
--- a/checklist.md
+++ b/checklist.md
@@ -28,7 +28,7 @@ For recommended system prompts that produce advanced markdown features, see [doc
 ### Phase 4: Polish & Launch (Weeks 13-16)
 
 - [ ] Comprehensive testing
-- [ ] Accessibility audit
+- [x] Accessibility audit
 - [ ] Documentation
 - [ ] Public release
 

--- a/ollama-ui/app/settings/page.tsx
+++ b/ollama-ui/app/settings/page.tsx
@@ -12,24 +12,33 @@ export default function Page() {
     <div className="p-6 space-y-4">
       <h1 className="text-xl font-semibold">Settings</h1>
       <div className="space-y-2">
-        <label className="block text-sm font-medium">Vector store path</label>
+        <label htmlFor="vector-path" className="block text-sm font-medium">
+          Vector store path
+        </label>
         <input
+          id="vector-path"
           type="text"
           className="border p-2 rounded w-full"
           onChange={(e) => setVectorStorePath(e.target.value)}
         />
       </div>
       <div className="space-y-2">
-        <label className="block text-sm font-medium">Embedding model</label>
+        <label htmlFor="embedding-model" className="block text-sm font-medium">
+          Embedding model
+        </label>
         <input
+          id="embedding-model"
           type="text"
           className="border p-2 rounded w-full"
           onChange={(e) => setEmbeddingModel(e.target.value)}
         />
       </div>
       <div className="space-y-2">
-        <label className="block text-sm font-medium">Reranking model</label>
+        <label htmlFor="reranking-model" className="block text-sm font-medium">
+          Reranking model
+        </label>
         <input
+          id="reranking-model"
           type="text"
           className="border p-2 rounded w-full"
           onChange={(e) => setRerankingModel(e.target.value)}

--- a/ollama-ui/components/chat/AgentStatus.tsx
+++ b/ollama-ui/components/chat/AgentStatus.tsx
@@ -4,5 +4,9 @@ import { useChatStore } from "@/stores/chat-store";
 export const AgentStatus = () => {
   const status = useChatStore((s) => s.status);
   if (!status) return null;
-  return <p className="text-xs italic text-gray-500 px-2">{status}</p>;
+  return (
+    <p className="text-xs italic text-gray-500 px-2" aria-live="polite">
+      {status}
+    </p>
+  );
 };

--- a/ollama-ui/components/chat/ChatInput.tsx
+++ b/ollama-ui/components/chat/ChatInput.tsx
@@ -25,6 +25,7 @@ export const ChatInput = ({ onSend, disabled }: ChatInputProps) => {
         value={text}
         onChange={(e) => setText(e.target.value)}
         disabled={disabled}
+        aria-label="Message input"
         rows={1}
       />
       <span className="text-xs text-gray-500 self-end pb-1">

--- a/ollama-ui/components/chat/ChatInterface.tsx
+++ b/ollama-ui/components/chat/ChatInterface.tsx
@@ -52,7 +52,11 @@ export const ChatInterface = () => {
         </div>
       </div>
       {isStreaming && <Progress value={progress} />}
-      <div className="flex-1 overflow-y-auto p-4 flex flex-col gap-2">
+      <div
+        className="flex-1 overflow-y-auto p-4 flex flex-col gap-2"
+        role="log"
+        aria-live="polite"
+      >
         {messages.map((m, i) => (
           <ChatMessage key={i} message={m} />
         ))}

--- a/ollama-ui/components/chat/ChatSettings.tsx
+++ b/ollama-ui/components/chat/ChatSettings.tsx
@@ -11,8 +11,13 @@ export const ChatSettings = () => {
   const [open, setOpen] = useState(false);
   return (
     <div className="relative">
-      <Button variant="outline" size="icon" onClick={() => setOpen((o) => !o)}>
-        <SettingsIcon className="w-4 h-4" />
+      <Button
+        variant="outline"
+        size="icon"
+        onClick={() => setOpen((o) => !o)}
+        aria-label="Chat settings"
+      >
+        <SettingsIcon className="w-4 h-4" aria-hidden />
       </Button>
       {open && (
         <div className="absolute right-0 mt-2 w-64 p-4 border rounded bg-background shadow">

--- a/ollama-ui/components/chat/ExportMenu.tsx
+++ b/ollama-ui/components/chat/ExportMenu.tsx
@@ -15,7 +15,7 @@ export const ExportMenu = () => {
         onClick={() => exportConversation(messages, "markdown")}
         aria-label="Export as Markdown"
       >
-        <Download className="w-4 h-4" />
+        <Download className="w-4 h-4" aria-hidden />
       </Button>
       <Button
         size="icon"
@@ -23,7 +23,7 @@ export const ExportMenu = () => {
         onClick={() => exportConversation(messages, "pdf")}
         aria-label="Export as PDF"
       >
-        <Download className="w-4 h-4" />
+        <Download className="w-4 h-4" aria-hidden />
       </Button>
       <Button
         size="icon"
@@ -31,7 +31,7 @@ export const ExportMenu = () => {
         onClick={() => exportConversation(messages, "json")}
         aria-label="Export as JSON"
       >
-        <Download className="w-4 h-4" />
+        <Download className="w-4 h-4" aria-hidden />
       </Button>
     </div>
   );

--- a/ollama-ui/components/markdown/AdvancedMarkdown.tsx
+++ b/ollama-ui/components/markdown/AdvancedMarkdown.tsx
@@ -52,7 +52,7 @@ export const AdvancedMarkdown = ({
                 onClick={() => exportMarkdown(content, "markdown")}
                 className="p-1 text-gray-400 hover:text-white"
               >
-                <Download className="w-4 h-4" />
+                <Download className="w-4 h-4" aria-hidden />
               </button>
               <button
                 type="button"
@@ -60,7 +60,7 @@ export const AdvancedMarkdown = ({
                 onClick={() => exportMarkdown(content, "html")}
                 className="p-1 text-gray-400 hover:text-white"
               >
-                <Download className="w-4 h-4" />
+                <Download className="w-4 h-4" aria-hidden />
               </button>
               <button
                 type="button"
@@ -68,7 +68,7 @@ export const AdvancedMarkdown = ({
                 onClick={() => exportMarkdown(content, "pdf")}
                 className="p-1 text-gray-400 hover:text-white"
               >
-                <Download className="w-4 h-4" />
+                <Download className="w-4 h-4" aria-hidden />
               </button>
             </>
           )}
@@ -84,7 +84,7 @@ export const AdvancedMarkdown = ({
               }}
               className="p-1 text-gray-400 hover:text-white"
             >
-              <Share2 className="w-4 h-4" />
+              <Share2 className="w-4 h-4" aria-hidden />
             </button>
           )}
         </div>

--- a/ollama-ui/components/markdown/CodeBlock.tsx
+++ b/ollama-ui/components/markdown/CodeBlock.tsx
@@ -193,7 +193,7 @@ export const CodeBlock = ({
             onClick={() => setShowNumbers((n) => !n)}
             className="text-gray-400 hover:text-white"
           >
-            <Hash className="w-4 h-4" />
+            <Hash className="w-4 h-4" aria-hidden />
           </button>
           <button
             type="button"
@@ -204,7 +204,7 @@ export const CodeBlock = ({
             }}
             className="text-gray-400 hover:text-white"
           >
-            <Search className="w-4 h-4" />
+            <Search className="w-4 h-4" aria-hidden />
           </button>
         </div>
         <div className="flex gap-1">
@@ -214,7 +214,11 @@ export const CodeBlock = ({
             onClick={handleCopy}
             className="text-gray-400 hover:text-white"
           >
-            {copied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
+            {copied ? (
+              <Check className="w-4 h-4" aria-hidden />
+            ) : (
+              <Copy className="w-4 h-4" aria-hidden />
+            )}
           </button>
           <button
             type="button"
@@ -222,7 +226,7 @@ export const CodeBlock = ({
             onClick={() => handleDownload("markdown")}
             className="text-gray-400 hover:text-white"
           >
-            <Download className="w-4 h-4" />
+            <Download className="w-4 h-4" aria-hidden />
           </button>
           {runnable && (
             <button
@@ -235,7 +239,7 @@ export const CodeBlock = ({
               }}
               className="text-gray-400 hover:text-white"
             >
-              <Play className="w-4 h-4" />
+              <Play className="w-4 h-4" aria-hidden />
             </button>
           )}
           {editable && (
@@ -245,7 +249,7 @@ export const CodeBlock = ({
               onClick={() => setEditing((e) => !e)}
               className="text-gray-400 hover:text-white"
             >
-              <Pencil className="w-4 h-4" />
+              <Pencil className="w-4 h-4" aria-hidden />
             </button>
           )}
           <button
@@ -254,7 +258,7 @@ export const CodeBlock = ({
             onClick={() => setFullscreen(true)}
             className="text-gray-400 hover:text-white"
           >
-            <Maximize2 className="w-4 h-4" />
+            <Maximize2 className="w-4 h-4" aria-hidden />
           </button>
         </div>
       </div>
@@ -317,7 +321,7 @@ export const CodeBlock = ({
           onClick={() => setFullscreen(false)}
           className="absolute top-2 right-2 text-white"
         >
-          <X className="w-5 h-5" />
+          <X className="w-5 h-5" aria-hidden />
         </button>
         {body}
       </div>

--- a/ollama-ui/components/markdown/CollapsibleSection.tsx
+++ b/ollama-ui/components/markdown/CollapsibleSection.tsx
@@ -16,7 +16,11 @@ export const CollapsibleSection = ({ title, children }: CollapsibleSectionProps)
         onClick={() => setOpen((o) => !o)}
         className="flex items-center gap-2 w-full px-3 py-2 bg-gray-800 text-left"
       >
-        {open ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
+        {open ? (
+          <ChevronDown className="w-4 h-4" aria-hidden />
+        ) : (
+          <ChevronRight className="w-4 h-4" aria-hidden />
+        )}
         <span className="font-medium">{title}</span>
       </button>
       {open && <div className="p-3">{children}</div>}

--- a/ollama-ui/components/markdown/MultiTabCodeBlock.tsx
+++ b/ollama-ui/components/markdown/MultiTabCodeBlock.tsx
@@ -97,15 +97,16 @@ export const MultiTabCodeBlock = ({ markdown }: MultiTabCodeBlockProps) => {
           aria-label="Toggle search"
           className="p-2 text-gray-400 hover:text-white"
         >
-          <Search className="w-4 h-4" />
+          <Search className="w-4 h-4" aria-hidden />
         </button>
       </div>
       {showSearch && (
         <div className="border-b border-gray-700 bg-gray-800 p-2 flex items-center gap-2">
-          <Search className="w-4 h-4 text-gray-400" />
+          <Search className="w-4 h-4 text-gray-400" aria-hidden />
           <input
             type="text"
             placeholder="Search..."
+            aria-label="Search code"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             className="flex-1 bg-transparent outline-none text-sm"

--- a/ollama-ui/components/models/ModelBrowser.tsx
+++ b/ollama-ui/components/models/ModelBrowser.tsx
@@ -82,6 +82,7 @@ export const ModelBrowser = ({ models, onSelect }: Props) => {
       <div className="flex flex-wrap gap-4 items-end">
         <input
           placeholder="Search models"
+          aria-label="Search models"
           className="flex-1 border px-2 py-1 rounded-md bg-background"
           value={filters.query}
           onChange={(e) => setFilters({ ...filters, query: e.target.value })}
@@ -104,6 +105,7 @@ export const ModelBrowser = ({ models, onSelect }: Props) => {
             type="number"
             className="w-16 border px-1 py-0.5 rounded-md"
             value={filters.sizeRange?.[0] || 0}
+            aria-label="Minimum size in MB"
             onChange={(e) =>
               setFilters({
                 ...filters,
@@ -116,6 +118,7 @@ export const ModelBrowser = ({ models, onSelect }: Props) => {
         <select
           className="border px-2 py-1 rounded-md"
           value={filters.sort}
+          aria-label="Sort models"
           onChange={(e) =>
             setFilters({ ...filters, sort: e.target.value as ModelFilters["sort"] })
           }

--- a/ollama-ui/components/models/ModelCard.tsx
+++ b/ollama-ui/components/models/ModelCard.tsx
@@ -46,12 +46,12 @@ export const ModelCard = ({ model, onSelect, isDownloaded }: ModelCardProps) => 
           </div>
           <div className="flex items-center gap-4 text-sm text-muted-foreground">
             <span className="flex items-center gap-1">
-              <Cpu className="w-3 h-3" />
+              <Cpu className="w-3 h-3" aria-hidden />
               {model.size}
             </span>
             {model.performance && (
               <span className="flex items-center gap-1">
-                <Clock className="w-3 h-3" />
+                <Clock className="w-3 h-3" aria-hidden />
                 {model.performance}
               </span>
             )}
@@ -59,7 +59,7 @@ export const ModelCard = ({ model, onSelect, isDownloaded }: ModelCardProps) => 
           <div className="flex gap-2">
             {isDownloaded ? (
               <Button className="flex-1" onClick={() => onSelect(model)}>
-                <Play className="w-4 h-4 mr-1" /> Launch
+                <Play className="w-4 h-4 mr-1" aria-hidden /> Launch
               </Button>
             ) : (
               <Button
@@ -71,13 +71,13 @@ export const ModelCard = ({ model, onSelect, isDownloaded }: ModelCardProps) => 
                   <span>{Math.round(downloadProgress[model.id])}%</span>
                 ) : (
                   <>
-                    <Download className="w-4 h-4 mr-1" /> Download
+                    <Download className="w-4 h-4 mr-1" aria-hidden /> Download
                   </>
                 )}
               </Button>
             )}
-            <Button variant="outline" size="icon">
-              <Info className="w-4 h-4" />
+            <Button variant="outline" size="icon" aria-label="Model info">
+              <Info className="w-4 h-4" aria-hidden />
             </Button>
           </div>
         </div>

--- a/ollama-ui/components/ui/ThemeToggle.tsx
+++ b/ollama-ui/components/ui/ThemeToggle.tsx
@@ -11,7 +11,11 @@ export const ThemeToggle = () => {
       aria-label="Toggle theme"
       className="p-2 border rounded text-gray-600 hover:text-black dark:text-gray-400 dark:hover:text-white"
     >
-      {theme === "dark" ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
+      {theme === "dark" ? (
+        <Sun className="w-4 h-4" aria-hidden />
+      ) : (
+        <Moon className="w-4 h-4" aria-hidden />
+      )}
     </button>
   );
 };

--- a/ollama-ui/components/ui/progress.tsx
+++ b/ollama-ui/components/ui/progress.tsx
@@ -1,5 +1,5 @@
 export const Progress = ({ value }: { value: number }) => (
-  <div className="w-full h-1 bg-gray-200 rounded">
+  <div className="w-full h-1 bg-gray-200 rounded" role="progressbar" aria-valuenow={Math.round(value)} aria-valuemin={0} aria-valuemax={100}>
     <div
       className="h-1 bg-ollama-green rounded"
       style={{ width: `${Math.min(100, Math.max(0, value))}%` }}

--- a/ollama-ui/components/ui/spinner.tsx
+++ b/ollama-ui/components/ui/spinner.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 export const Spinner = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn("animate-spin", className)} {...props}>
+  <div className={cn("animate-spin", className)} role="status" aria-label="Loading" {...props}>
     <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none">
       <circle
         className="opacity-25"

--- a/ollama-ui/components/ui/toast.tsx
+++ b/ollama-ui/components/ui/toast.tsx
@@ -13,7 +13,10 @@ export const Toast = ({ message, onDismiss }: ToastProps) => {
   }, [onDismiss]);
 
   return (
-    <div className="fixed bottom-4 right-4 bg-red-500 text-white px-3 py-2 rounded shadow">
+    <div
+      role="alert"
+      className="fixed bottom-4 right-4 bg-red-500 text-white px-3 py-2 rounded shadow"
+    >
       {message}
     </div>
   );


### PR DESCRIPTION
## Summary
- improve keyboard and screen reader accessibility across UI components
- label chat textarea and settings controls
- add aria attributes to dynamic regions and icons
- expose progress indicators and spinners for screen readers
- mark Phase 4 accessibility audit complete in checklist

## Testing
- `pnpm build`
- `pnpm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_684d451143a88323a6cdbc467c5ab402