### PR TITLE
Improve stability and backend services

### DIFF
--- a/ollama-ui/app/layout.tsx
+++ b/ollama-ui/app/layout.tsx
@@ -7,7 +7,6 @@ import Header from "@/components/Header";
 import HeaderSkeleton from "@/components/HeaderSkeleton";
 import ServiceWorkerRegister from "@/components/ServiceWorkerRegister";
 import { ServiceWorkerProvider } from "@/components/performance";
-import { MainShell } from "@/components/layout";
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -31,8 +30,6 @@ export default function RootLayout({
           </MainShell>
           <ServiceWorkerRegister />
           <ServiceWorkerProvider />
-          <ServiceWorkerProvider />
-          <MainShell>{children}</MainShell>
         </ThemeProvider>
       </body>
     </html>

--- a/ollama-ui/app/page.tsx
+++ b/ollama-ui/app/page.tsx
@@ -2,39 +2,4 @@ import { LandingHero } from "@/components/landing";
 
 export default async function Home() {
   return <LandingHero />;
-import Link from "next/link";
-import Image from "next/image";
-
-export default function Home() {
-  return (
-    <section className="relative flex flex-col items-center justify-center text-center py-24 gap-10">
-      <h1 className="text-4xl font-bold">Ollama Web Interface</h1>
-      <p className="text-muted-foreground max-w-md">
-        Manage local models and chat with them using a sleek interface.
-      </p>
-      <div className="flex gap-4">
-        <Link
-          href="/models"
-          className="bg-primary text-primary-foreground px-6 py-3 rounded-md hover:opacity-90"
-        >
-          Browse Models
-        </Link>
-        <Link
-          href="/chat"
-          className="border px-6 py-3 rounded-md hover:bg-accent"
-        >
-          Start Chatting
-        </Link>
-      </div>
-      <div className="pointer-events-none absolute inset-0 overflow-hidden">
-        <Image
-          src="/next.svg"
-          alt="Decor"
-          width={400}
-          height={400}
-          className="opacity-5 absolute -top-10 -right-10 animate-pulse"
-        />
-      </div>
-    </section>
-  );
 }

--- a/ollama-ui/components/ServiceWorkerRegister.tsx
+++ b/ollama-ui/components/ServiceWorkerRegister.tsx
@@ -1,0 +1,13 @@
+"use client";
+import { useEffect } from "react";
+
+export default function ServiceWorkerRegister() {
+  useEffect(() => {
+    if ("serviceWorker" in navigator) {
+      navigator.serviceWorker
+        .register("/sw.js")
+        .catch((err) => console.error("Service worker registration failed", err));
+    }
+  }, []);
+  return null;
+}

--- a/ollama-ui/components/layout/MainShell.tsx
+++ b/ollama-ui/components/layout/MainShell.tsx
@@ -1,14 +1,3 @@
-import React from "react";
-import Header from "@/components/Header";
-
-export const MainShell = ({ children }: { children: React.ReactNode }) => {
-  return (
-    <div className="min-h-screen flex flex-col">
-      <Header />
-      <main className="flex-1">{children}</main>
-    </div>
-  );
-};
 import { ReactNode, Suspense } from "react";
 import NavigationHeader from "./NavigationHeader";
 import HeaderSkeleton from "../HeaderSkeleton";

--- a/ollama-ui/components/layout/index.ts
+++ b/ollama-ui/components/layout/index.ts
@@ -1,3 +1,2 @@
-export * from "./MainShell";
-export { default as NavigationHeader } from "./NavigationHeader";
 export { default as MainShell } from "./MainShell";
+export { default as NavigationHeader } from "./NavigationHeader";

--- a/ollama-ui/src/lib/vector/store.ts
+++ b/ollama-ui/src/lib/vector/store.ts
@@ -12,8 +12,6 @@ export class VectorStoreService {
   private docs: Document[] = [];
   private embeddings: Embedding[] = [];
   private searchCache = new Map<string, SearchResult[]>();
-  private searchOrder: string[] = [];
-  private maxCache = 50;
   private cacheOrder: string[] = [];
   private readonly MAX_CACHE = 50;
   private embedder = new EmbeddingService(
@@ -21,6 +19,7 @@ export class VectorStoreService {
   );
 
   async initialize(options: VectorStoreOptions): Promise<void> {
+    if (this.initialized) return;
     void options;
     this.initialized = true;
   }

--- a/ollama-ui/src/services/embedding-service.ts
+++ b/ollama-ui/src/services/embedding-service.ts
@@ -51,10 +51,6 @@ export class EmbeddingService {
   }
 
   async generateEmbeddings(texts: string[], model: string): Promise<Embedding[]> {
-    const embeddings: Embedding[] = [];
-    for (const t of texts) {
-      embeddings.push(await this.generateEmbedding(t, model));
-    }
-    return embeddings;
+    return Promise.all(texts.map((t) => this.generateEmbedding(t, model)));
   }
 }

--- a/ollama-ui/src/services/reranker-service.ts
+++ b/ollama-ui/src/services/reranker-service.ts
@@ -2,11 +2,15 @@ import type { SearchResult } from "@/types";
 
 export class RerankerService {
   async rerank(query: string, results: SearchResult[]): Promise<SearchResult[]> {
-    // Simple lexical scoring fallback
-    const scored = results.map((r) => ({
-      ...r,
-      score: r.score + (r.text.includes(query) ? 1 : 0),
-    }));
+    const tokens = query.toLowerCase().split(/\s+/).filter(Boolean);
+    const scored = results.map((r) => {
+      const text = r.text.toLowerCase();
+      const extra = tokens.reduce(
+        (acc, t) => (text.includes(t) ? acc + 1 : acc),
+        0,
+      );
+      return { ...r, score: r.score + extra };
+    });
     return scored.sort((a, b) => b.score - a.score);
   }
 }

--- a/ollama-ui/stores/chat-store.ts
+++ b/ollama-ui/stores/chat-store.ts
@@ -127,49 +127,10 @@ export const useChatStore = create<ChatState>((set, get) => ({
         console.error("Pipeline run failed", error);
         set({ status: "Unexpected error", error: "Pipeline failed" });
       }
-      set({ isStreaming: false, status: null, thinking: null, tokens: null, docs: [], tools: [], abortController: null });
-
-      for await (const out of pipeline.run([...current, userMsg])) {
-        if (out.type === "status") {
-          set({ status: out.message });
-          continue;
-        }
-        if (out.type === "docs") {
-          set({ docs: out.docs });
-          continue;
-        }
-        if (out.type === "thinking") {
-          set({ thinking: out.message });
-          continue;
-        }
-        if (out.type === "error") {
-          set({ error: out.message });
-          continue;
-        }
-        if (out.type === "summary") {
-          set({ summary: out.message });
-          continue;
-        }
-        if (out.type === "tokens") {
-          set({ tokens: out.count });
-          continue;
-        }
-        if (out.type === "tool") {
-          set((state) => ({ tools: [...state.tools, { name: out.name, output: out.output }] }));
-          continue;
-        }
-        assistant = { ...assistant, content: assistant.content + out.chunk.message };
-        set((state) => {
-          const msgs = [...state.messages];
-          msgs[msgs.length - 1] = assistant;
-          return { messages: msgs };
-        });
+        set({ isStreaming: false, status: null, thinking: null, tokens: null, docs: [], tools: [], abortController: null });
+        set((state) => ({ messages: [...state.messages, assistant] }));
+        return;
       }
-      set({ isStreaming: false, status: null, thinking: null, tokens: null, docs: [], tools: [] });
-      set((state) => ({ messages: [...state.messages, assistant] }));
-      set({ isStreaming: false, status: null, abortController: null });
-      return;
-    }
 
     const client = new OllamaClient({
       baseUrl: process.env.OLLAMA_BASE_URL || "http://localhost:11434",


### PR DESCRIPTION
## Summary
- fix duplicated layout components
- simplify landing page
- remove duplicate MainShell export
- add service worker registration
- run embeddings in parallel
- streamline vector store initialization and caching
- improve Ollama client error handling
- enhance reranker scoring
- clean up chat store pipeline

## Testing
- `pnpm build`
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684d7a2e3f84832399264a1f66127a11