### PR TITLE
Improve model management UX and robustness

### DIFF
--- a/docs/model-browser/overview.md
+++ b/docs/model-browser/overview.md
@@ -13,6 +13,7 @@ Provide a rich interface to browse and manage models available from the local Ol
 - Size range slider filters models by download size.
 - Sort options include Popular, Recent, Size and Performance.
 - Download action triggers `OllamaClient.pullModel()` (not yet implemented in UI).
+- A **Downloaded Models** tab lists locally stored models with usage statistics and bulk delete actions.
 
 ## Primary Types
 

--- a/docs/ollama-connection/overview.md
+++ b/docs/ollama-connection/overview.md
@@ -10,6 +10,7 @@ Ollama.
 ## Core Flows and UI Touchpoints
 
 - Create an `OllamaClient` with a base URL.
+- The base URL is centralized in `src/lib/config.ts`.
 - Automatically reconnect on connection loss.
 - Expose methods for model queries and chat streaming.
 - Downstream features such as the model browser and chat UI rely on this service.

--- a/ollama-ui/app/models/page.tsx
+++ b/ollama-ui/app/models/page.tsx
@@ -1,16 +1,19 @@
 import dynamic from "next/dynamic";
 import { getAvailableModels, getModelStats } from "@/lib/ollama/server";
 
-const ModelBrowser = dynamic(() =>
-  import("@/components/models").then((m) => m.ModelBrowser),
+const ModelManager = dynamic(
+  () => import("@/components/models").then((m) => m.ModelManager),
+  {
+    loading: () =>
+      import("@/components/models").then((m) => <m.ModelBrowserSkeleton />),
+  },
 );
 
 
 export default async function Page() {
-  const [models, stats] = await Promise.all([getAvailableModels(), getModelStats()]);
-  return (
-    <div className="p-6">
-      <ModelBrowser models={models} stats={stats} />
-    </div>
-  );
+  const [models, stats] = await Promise.all([
+    getAvailableModels(),
+    getModelStats(),
+  ]);
+  return <ModelManager models={models} stats={stats} />;
 }

--- a/ollama-ui/components/models/DownloadedModels.tsx
+++ b/ollama-ui/components/models/DownloadedModels.tsx
@@ -1,0 +1,49 @@
+"use client";
+import { useState } from "react";
+import { useModelStore } from "@/stores/model-store";
+import { ModelCard } from "./ModelCard";
+import { Button } from "@/components/ui/button";
+
+export const DownloadedModels = () => {
+  const { available, downloaded, deleteModels, usage } = useModelStore();
+  const [selected, setSelected] = useState<string[]>([]);
+  const models = available.filter((m) => downloaded.includes(m.id));
+
+  const toggle = (id: string) => {
+    setSelected((s) => (s.includes(id) ? s.filter((i) => i !== id) : [...s, id]));
+  };
+
+  return (
+    <div className="space-y-4">
+      {selected.length > 0 && (
+        <Button onClick={() => { deleteModels(selected); setSelected([]); }}>
+          Delete Selected
+        </Button>
+      )}
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+        {models.map((m) => (
+          <div key={m.id} className="relative">
+            <input
+              type="checkbox"
+              className="absolute top-2 left-2 z-10"
+              checked={selected.includes(m.id)}
+              onChange={() => toggle(m.id)}
+              aria-label="Select model"
+            />
+            <ModelCard
+              model={m}
+              onSelect={() => window.location.assign('/chat/new')}
+              isDownloaded
+            />
+            {usage[m.id] && (
+              <div className="absolute bottom-2 right-2 text-xs bg-black/50 px-1 rounded">
+                {usage[m.id].uses} uses
+                {usage[m.id].lastUsed && ` · ${new Date(usage[m.id].lastUsed as string).toLocaleDateString()}`}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/ollama-ui/components/models/ModelBrowserSkeleton.tsx
+++ b/ollama-ui/components/models/ModelBrowserSkeleton.tsx
@@ -1,0 +1,10 @@
+"use client";
+import { ModelCardSkeleton } from "./ModelCardSkeleton";
+
+export const ModelBrowserSkeleton = () => (
+  <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 p-6">
+    {Array.from({ length: 6 }).map((_, i) => (
+      <ModelCardSkeleton key={i} />
+    ))}
+  </div>
+);

--- a/ollama-ui/components/models/ModelCard.tsx
+++ b/ollama-ui/components/models/ModelCard.tsx
@@ -7,6 +7,14 @@ import { Button } from "@/components/ui/button";
 import type { Model } from "@/types";
 import { useModelStore } from "@/stores/model-store";
 
+function getModelGradient(caps?: string[]) {
+  if (!caps || caps.length === 0) return "from-green-600 to-blue-600";
+  if (caps.includes("Vision")) return "from-pink-600 to-purple-600";
+  if (caps.includes("Code")) return "from-yellow-500 to-orange-600";
+  if (caps.includes("Chat")) return "from-green-600 to-blue-600";
+  return "from-indigo-600 to-blue-600";
+}
+
 interface ModelCardProps {
   model: Model;
   onSelect: (model: Model) => void;
@@ -14,7 +22,7 @@ interface ModelCardProps {
 }
 
 export const ModelCard = ({ model, onSelect, isDownloaded }: ModelCardProps) => {
-  const { downloadModel, downloadProgress } = useModelStore();
+  const { downloadModel, downloadProgress, markUsed } = useModelStore();
   return (
     <motion.div
       initial={{ opacity: 0, y: 20 }}
@@ -25,7 +33,9 @@ export const ModelCard = ({ model, onSelect, isDownloaded }: ModelCardProps) => 
     >
       <Card className="overflow-hidden glass-morphism border-white/10 hover:border-white/20 transition-all duration-300">
         <div className="h-32 relative overflow-hidden">
-          <div className="absolute inset-0 bg-gradient-to-br from-green-600 to-blue-600" />
+          <div
+            className={`absolute inset-0 bg-gradient-to-br ${getModelGradient(model.capabilities)}`}
+          />
           <div className="absolute inset-0 bg-black/20" />
           <div className="absolute top-2 right-2 flex gap-1">
             {model.capabilities?.map((cap) => (
@@ -58,7 +68,13 @@ export const ModelCard = ({ model, onSelect, isDownloaded }: ModelCardProps) => 
           </div>
           <div className="flex gap-2">
             {isDownloaded ? (
-              <Button className="flex-1" onClick={() => onSelect(model)}>
+              <Button
+                className="flex-1"
+                onClick={() => {
+                  markUsed(model.id);
+                  onSelect(model);
+                }}
+              >
                 <Play className="w-4 h-4 mr-1" aria-hidden /> Launch
               </Button>
             ) : (

--- a/ollama-ui/components/models/ModelCardSkeleton.tsx
+++ b/ollama-ui/components/models/ModelCardSkeleton.tsx
@@ -1,0 +1,13 @@
+"use client";
+import { Card } from "@/components/ui/card";
+
+export const ModelCardSkeleton = () => (
+  <Card className="overflow-hidden animate-pulse border-white/10">
+    <div className="h-32 bg-muted" />
+    <div className="p-4 space-y-2">
+      <div className="h-4 bg-muted rounded w-3/4" />
+      <div className="h-3 bg-muted rounded w-1/2" />
+      <div className="h-8 bg-muted rounded" />
+    </div>
+  </Card>
+);

--- a/ollama-ui/components/models/ModelManager.tsx
+++ b/ollama-ui/components/models/ModelManager.tsx
@@ -1,0 +1,37 @@
+"use client";
+import { useState } from "react";
+import { ModelBrowser } from "./ModelBrowser";
+import { DownloadedModels } from "./DownloadedModels";
+import type { Model, ModelStats } from "@/types";
+
+interface Props {
+  models: Model[];
+  stats: ModelStats;
+}
+
+export const ModelManager = ({ models, stats }: Props) => {
+  const [tab, setTab] = useState<'browse' | 'downloaded'>('browse');
+  return (
+    <div className="p-6 space-y-4">
+      <div className="flex gap-4 border-b pb-2">
+        <button
+          className={`${tab === 'browse' ? 'font-semibold border-b-2' : 'text-muted-foreground'}`}
+          onClick={() => setTab('browse')}
+        >
+          Browse Models
+        </button>
+        <button
+          className={`${tab === 'downloaded' ? 'font-semibold border-b-2' : 'text-muted-foreground'}`}
+          onClick={() => setTab('downloaded')}
+        >
+          Downloaded Models
+        </button>
+      </div>
+      {tab === 'browse' ? (
+        <ModelBrowser models={models} stats={stats} />
+      ) : (
+        <DownloadedModels />
+      )}
+    </div>
+  );
+};

--- a/ollama-ui/components/models/index.ts
+++ b/ollama-ui/components/models/index.ts
@@ -1,2 +1,6 @@
 export * from "./ModelCard";
 export * from "./ModelBrowser";
+export * from "./ModelBrowserSkeleton";
+export * from "./ModelCardSkeleton";
+export * from "./ModelManager";
+export * from "./DownloadedModels";

--- a/ollama-ui/src/lib/config.ts
+++ b/ollama-ui/src/lib/config.ts
@@ -1,0 +1,2 @@
+export const OLLAMA_BASE_URL =
+  process.env.OLLAMA_BASE_URL || "http://localhost:11434";

--- a/ollama-ui/src/lib/langchain/ollama-chat.ts
+++ b/ollama-ui/src/lib/langchain/ollama-chat.ts
@@ -1,12 +1,13 @@
 import type { ChatRequest, ChatResponse, ChatSettings } from "@/types";
 import { OllamaClient } from "@/lib/ollama/client";
+import { OLLAMA_BASE_URL } from "@/lib/config";
 
 export class OllamaChat {
   private client: OllamaClient;
 
   constructor(private settings: ChatSettings & { baseUrl?: string }) {
     this.client = new OllamaClient({
-      baseUrl: settings.baseUrl || "http://localhost:11434",
+      baseUrl: settings.baseUrl || OLLAMA_BASE_URL,
     });
   }
 

--- a/ollama-ui/src/lib/ollama/server.ts
+++ b/ollama-ui/src/lib/ollama/server.ts
@@ -1,7 +1,8 @@
 import { cache } from "react";
 import type { Model, ModelStats, OllamaStatus } from "@/types";
+import { OLLAMA_BASE_URL } from "@/lib/config";
 
-const BASE_URL = process.env.OLLAMA_BASE_URL || "http://localhost:11434";
+const BASE_URL = OLLAMA_BASE_URL;
 
 export const getAvailableModels = cache(async (): Promise<Model[]> => {
   try {

--- a/ollama-ui/src/lib/vector/store.ts
+++ b/ollama-ui/src/lib/vector/store.ts
@@ -6,6 +6,7 @@ import type {
   Embedding,
 } from "@/types";
 import { EmbeddingService } from "@/services/embedding-service";
+import { OLLAMA_BASE_URL } from "@/lib/config";
 
 export class VectorStoreService {
   private initialized = false;
@@ -20,9 +21,7 @@ export class VectorStoreService {
   private cacheOrder: string[] = [];
   private readonly MAX_CACHE = 50;
   private readonly CACHE_TTL = 300_000; // 5 minutes
-  private embedder = new EmbeddingService(
-    process.env.OLLAMA_BASE_URL || "http://localhost:11434",
-  );
+  private embedder = new EmbeddingService(OLLAMA_BASE_URL);
 
   async initialize(options: VectorStoreOptions): Promise<void> {
     if (this.initialized) return;

--- a/ollama-ui/stores/chat-store.ts
+++ b/ollama-ui/stores/chat-store.ts
@@ -5,6 +5,7 @@ import { vectorStore } from "@/lib/vector";
 import { createAgentPipeline } from "@/services/agent-pipeline";
 import { useSettingsStore } from "./settings-store";
 import { MARKDOWN_INSTRUCTIONS } from "@/lib/markdown-prompts";
+import { OLLAMA_BASE_URL } from "@/lib/config";
 
 type ChatMode = "simple" | "agentic";
 
@@ -133,7 +134,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       }
 
     const client = new OllamaClient({
-      baseUrl: process.env.OLLAMA_BASE_URL || "http://localhost:11434",
+      baseUrl: OLLAMA_BASE_URL,
     });
     let assistant: Message = { id: crypto.randomUUID(), role: "assistant", content: "" };
     set((state) => ({ messages: [...state.messages, assistant] }));

--- a/ollama-ui/stores/model-store.ts
+++ b/ollama-ui/stores/model-store.ts
@@ -1,44 +1,82 @@
 import { create } from "zustand";
 import type { Model, PullProgress } from "@/types";
 import { OllamaClient } from "@/lib/ollama/client";
+import { OLLAMA_BASE_URL } from "@/lib/config";
 
 interface ModelState {
   available: Model[];
   downloaded: string[];
   downloadProgress: Record<string, number>;
+  usage: Record<string, { uses: number; lastUsed: string | null }>;
+  error: string | null;
   fetchModels: () => Promise<void>;
   downloadModel: (id: string) => Promise<void>;
+  deleteModels: (ids: string[]) => void;
+  markUsed: (id: string) => void;
 }
 
 export const useModelStore = create<ModelState>((set, get) => ({
   available: [],
   downloaded: [],
   downloadProgress: {},
+  usage: {},
+  error: null,
   async fetchModels() {
-    const client = new OllamaClient({
-      baseUrl: process.env.OLLAMA_BASE_URL || "http://localhost:11434",
-    });
-    const models = await client.listModels();
-    set({ available: models });
+    try {
+      const client = new OllamaClient({
+        baseUrl: OLLAMA_BASE_URL,
+      });
+      const models = await client.listModels();
+      set({ available: models, error: null });
+    } catch (e) {
+      set({ error: (e as Error).message });
+    }
   },
   async downloadModel(id: string) {
-    const client = new OllamaClient({
-      baseUrl: process.env.OLLAMA_BASE_URL || "http://localhost:11434",
-    });
-    set((state) => ({
-      downloadProgress: { ...state.downloadProgress, [id]: 0 },
-    }));
-    await client.pullModel(id, (p: PullProgress) => {
+    try {
+      const client = new OllamaClient({
+        baseUrl: OLLAMA_BASE_URL,
+      });
       set((state) => ({
-        downloadProgress: { ...state.downloadProgress, [id]: p.progress },
+        downloadProgress: { ...state.downloadProgress, [id]: 0 },
       }));
-    });
-    set((state) => {
-      const { [id]: _removed, ...rest } = state.downloadProgress;
-      return {
-        downloaded: [...state.downloaded, id],
-        downloadProgress: rest,
-      };
-    });
+      await client.pullModel(id, (p: PullProgress) => {
+        set((state) => ({
+          downloadProgress: { ...state.downloadProgress, [id]: p.progress },
+        }));
+      });
+      set((state) => {
+        const { [id]: _removed, ...rest } = state.downloadProgress;
+        return {
+          downloaded: [...state.downloaded, id],
+          downloadProgress: rest,
+          usage: {
+            ...state.usage,
+            [id]: { uses: 0, lastUsed: null },
+          },
+        };
+      });
+    } catch (e) {
+      set({ error: (e as Error).message });
+    }
+  },
+  deleteModels(ids: string[]) {
+    set((state) => ({
+      downloaded: state.downloaded.filter((d) => !ids.includes(d)),
+      usage: Object.fromEntries(
+        Object.entries(state.usage).filter(([k]) => !ids.includes(k)),
+      ),
+    }));
+  },
+  markUsed(id: string) {
+    set((state) => ({
+      usage: {
+        ...state.usage,
+        [id]: {
+          uses: (state.usage[id]?.uses || 0) + 1,
+          lastUsed: new Date().toISOString(),
+        },
+      },
+    }));
   },
 }));


### PR DESCRIPTION
## Summary
- add loading skeleton for models page
- style model cards by capability and track usage
- implement downloaded models tab with bulk delete
- centralize Ollama base URL constant
- document new functionality and config location

## Testing
- `pnpm --filter ollama-ui build`
- `pnpm --filter ollama-ui test` *(fails: Exit status 130)*

------
https://chatgpt.com/codex/tasks/task_e_684d911d9a448323af96dc6bca13b89d